### PR TITLE
Curry m to operator form: m(α)(z)

### DIFF
--- a/rieszreg/python/rieszreg/estimands/base.py
+++ b/rieszreg/python/rieszreg/estimands/base.py
@@ -3,7 +3,11 @@
 An `Estimand` carries (1) the column names alpha is indexed by (`feature_keys`),
 (2) per-row payload columns that aren't fit-time inputs but are referenced by
 m (`extra_keys`, e.g. "shift_samples" for stochastic interventions), and (3)
-the opaque m(z, alpha) callable itself.
+the opaque `m(alpha)(z)` operator itself.
+
+`m` is an operator: it takes a candidate function `alpha` and returns a function
+of the row `z`. The orchestrator calls `m(alpha)(z)` row-by-row, passing a
+`Tracer` for `alpha` to extract the linear-form structure.
 
 The orchestrator estimator reads `feature_keys` and `extra_keys` off the
 estimand at fit time — no need for the user to pass these as separate arguments.
@@ -30,8 +34,8 @@ class Estimand:
     # None and rely on the user's m being picklable on its own.
     factory_spec: dict | None = None
 
-    def __call__(self, z, alpha):
-        return self.m(z, alpha)
+    def __call__(self, alpha):
+        return self.m(alpha)
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Estimand):
@@ -86,9 +90,11 @@ def ATE(treatment: str = "a", covariates: Sequence[str] = ("x",)) -> Estimand:
     """Average treatment effect: m(α)(z) = α(1, x) − α(0, x)."""
     cov = tuple(covariates)
 
-    def m(z, alpha):
-        x_kwargs = {k: z[k] for k in cov}
-        return alpha(**{treatment: 1, **x_kwargs}) - alpha(**{treatment: 0, **x_kwargs})
+    def m(alpha):
+        def inner(z):
+            x_kwargs = {k: z[k] for k in cov}
+            return alpha(**{treatment: 1, **x_kwargs}) - alpha(**{treatment: 0, **x_kwargs})
+        return inner
 
     return Estimand(
         feature_keys=(treatment, *cov), m=m, name="ATE",
@@ -104,12 +110,14 @@ def ATT(treatment: str = "a", covariates: Sequence[str] = ("x",)) -> Estimand:
     """
     cov = tuple(covariates)
 
-    def m(z, alpha):
-        a = z[treatment]
-        x_kwargs = {k: z[k] for k in cov}
-        return a * (
-            alpha(**{treatment: 1, **x_kwargs}) - alpha(**{treatment: 0, **x_kwargs})
-        )
+    def m(alpha):
+        def inner(z):
+            a = z[treatment]
+            x_kwargs = {k: z[k] for k in cov}
+            return a * (
+                alpha(**{treatment: 1, **x_kwargs}) - alpha(**{treatment: 0, **x_kwargs})
+            )
+        return inner
 
     return Estimand(
         feature_keys=(treatment, *cov), m=m, name="ATT",
@@ -121,9 +129,11 @@ def TSM(level, treatment: str = "a", covariates: Sequence[str] = ("x",)) -> Esti
     """Treatment-specific mean: m(α)(z) = α(level, x)."""
     cov = tuple(covariates)
 
-    def m(z, alpha):
-        x_kwargs = {k: z[k] for k in cov}
-        return alpha(**{treatment: level, **x_kwargs})
+    def m(alpha):
+        def inner(z):
+            x_kwargs = {k: z[k] for k in cov}
+            return alpha(**{treatment: level, **x_kwargs})
+        return inner
 
     return Estimand(
         feature_keys=(treatment, *cov), m=m, name=f"TSM(level={level!r})",
@@ -137,12 +147,14 @@ def AdditiveShift(
     """Additive shift effect: m(α)(z) = α(a + δ, x) − α(a, x)."""
     cov = tuple(covariates)
 
-    def m(z, alpha):
-        a = z[treatment]
-        x_kwargs = {k: z[k] for k in cov}
-        return alpha(**{treatment: a + delta, **x_kwargs}) - alpha(
-            **{treatment: a, **x_kwargs}
-        )
+    def m(alpha):
+        def inner(z):
+            a = z[treatment]
+            x_kwargs = {k: z[k] for k in cov}
+            return alpha(**{treatment: a + delta, **x_kwargs}) - alpha(
+                **{treatment: a, **x_kwargs}
+            )
+        return inner
 
     return Estimand(
         feature_keys=(treatment, *cov), m=m, name=f"AdditiveShift(delta={delta})",
@@ -162,14 +174,16 @@ def LocalShift(
     """
     cov = tuple(covariates)
 
-    def m(z, alpha):
-        a = z[treatment]
-        if a >= threshold:
-            return 0
-        x_kwargs = {k: z[k] for k in cov}
-        return alpha(**{treatment: a + delta, **x_kwargs}) - alpha(
-            **{treatment: a, **x_kwargs}
-        )
+    def m(alpha):
+        def inner(z):
+            a = z[treatment]
+            if a >= threshold:
+                return 0
+            x_kwargs = {k: z[k] for k in cov}
+            return alpha(**{treatment: a + delta, **x_kwargs}) - alpha(
+                **{treatment: a, **x_kwargs}
+            )
+        return inner
 
     return Estimand(
         feature_keys=(treatment, *cov),
@@ -196,15 +210,17 @@ def StochasticIntervention(
     """
     cov = tuple(covariates)
 
-    def m(z, alpha):
-        x_kwargs = {k: z[k] for k in cov}
-        samples = z[samples_key]
-        K = len(samples)
-        if K == 0:
-            return 0
-        return sum(
-            alpha(**{treatment: float(s), **x_kwargs}) for s in samples
-        ) / K
+    def m(alpha):
+        def inner(z):
+            x_kwargs = {k: z[k] for k in cov}
+            samples = z[samples_key]
+            K = len(samples)
+            if K == 0:
+                return 0
+            return sum(
+                alpha(**{treatment: float(s), **x_kwargs}) for s in samples
+            ) / K
+        return inner
 
     return Estimand(
         feature_keys=(treatment, *cov),

--- a/rieszreg/python/rieszreg/estimands/tracer.py
+++ b/rieszreg/python/rieszreg/estimands/tracer.py
@@ -1,9 +1,11 @@
 """Symbolic tracer that extracts (coefficient, point) terms from a user's m().
 
-The user writes m opaquely:
+The user writes m as an operator: it takes alpha and returns a function of z.
 
-    def m_ate(z, alpha):
-        return alpha(a=1, x=z["x"]) - alpha(a=0, x=z["x"])
+    def m_ate(alpha):
+        def inner(z):
+            return alpha(a=1, x=z["x"]) - alpha(a=0, x=z["x"])
+        return inner
 
 We pass a `Tracer` in as `alpha`. Each call records a `LinearTerm`; arithmetic
 builds a `LinearForm`. If the user's m stays inside the linear-form algebra
@@ -102,17 +104,18 @@ class LinearForm:
 
 
 class Tracer:
-    """Stand-in for `alpha` during tracing. Each call records a single-term
-    LinearForm; the user's m composes these via +/-/scalar*."""
+    """Stand-in for `alpha` during tracing. The trace step calls
+    `m(Tracer())(z)`; each `alpha(...)` call inside the user's m records a
+    single-term LinearForm, and the user's m composes these via +/-/scalar*."""
 
     def __call__(self, **kwargs) -> LinearForm:
         return LinearForm.single(_Point.from_kwargs(kwargs), 1.0)
 
 
 def trace(m, z) -> list[tuple[float, dict[str, Any]]]:
-    """Run the user's m on a single row z with the Tracer as alpha and return
-    the (coef, point) pair list. Raises if m leaves the linear-form algebra."""
-    result = m(z, Tracer())
+    """Run the user's m as `m(Tracer())(z)` on a single row z and return the
+    (coef, point) pair list. Raises if m leaves the linear-form algebra."""
+    result = m(Tracer())(z)
     if isinstance(result, (int, float)):
         if result == 0:
             return []

--- a/rieszreg/python/rieszreg/estimator.py
+++ b/rieszreg/python/rieszreg/estimator.py
@@ -99,7 +99,7 @@ class RieszEstimator(BaseEstimator):
     Parameters
     ----------
     estimand : Estimand
-        Carries `feature_keys`, `extra_keys`, and the `m(z, alpha)` callable.
+        Carries `feature_keys`, `extra_keys`, and the `m(alpha)(z)` operator.
         Required.
     backend : Backend
         Concrete backend implementing the `fit_augmented` (or `fit_rows`)

--- a/rieszreg/python/tests/test_augmentation.py
+++ b/rieszreg/python/tests/test_augmentation.py
@@ -31,7 +31,7 @@ def test_original_rows_have_a_one_b_zero():
     mask = (aug.features[:, 0] == 0.5) & (aug.features[:, 1] == 1.5)
     assert mask.sum() == 1  # original row distinct from counterfactual
     # On the original row, a=1, b=-2*coef where coef is from m at this point.
-    # m(z, alpha) = alpha(a + delta, x) - alpha(a, x). At a=0.5: coef on
+    # m(alpha)(z) = alpha(a + delta, x) - alpha(a, x). At a=0.5: coef on
     # alpha(a=0.5, x=1.5) is -1, so b = +2. Plus the natural a=1 contribution.
     assert aug.a[mask].item() == 1.0
     assert aug.b[mask].item() == 2.0

--- a/rieszreg/python/tests/test_estimand_factories.py
+++ b/rieszreg/python/tests/test_estimand_factories.py
@@ -64,7 +64,7 @@ def test_estimand_from_spec_unknown_factory_raises():
 def test_ate_traces_to_correct_pairs():
     pairs = trace(ATE(), {"a": 0.0, "x": 1.5})
     points = {tuple(sorted(p.items())): c for c, p in pairs}
-    # m(z, alpha) = alpha(a=1, x=1.5) - alpha(a=0, x=1.5)
+    # m(alpha)(z) = alpha(a=1, x=1.5) - alpha(a=0, x=1.5)
     assert points[(("a", 1), ("x", 1.5))] == pytest.approx(1.0)
     assert points[(("a", 0), ("x", 1.5))] == pytest.approx(-1.0)
 
@@ -84,8 +84,10 @@ def test_local_shift_zero_above_threshold():
 
 
 def test_custom_estimand_pickle_uses_factory_spec_when_set():
-    def m(z, alpha):
-        return alpha(a=1, x=z["x"]) - alpha(a=0, x=z["x"])
+    def m(alpha):
+        def inner(z):
+            return alpha(a=1, x=z["x"]) - alpha(a=0, x=z["x"])
+        return inner
 
     est = Estimand(feature_keys=("a", "x"), m=m, name="custom")
     # No factory_spec → falls back to default reduce; tested elsewhere.

--- a/rieszreg/python/tests/test_tracer.py
+++ b/rieszreg/python/tests/test_tracer.py
@@ -62,23 +62,29 @@ def test_constant_addition_raises():
 
 
 def test_squaring_raises():
-    def m(z, alpha):
-        return alpha(a=1, x=z["x"]) ** 2
+    def m(alpha):
+        def inner(z):
+            return alpha(a=1, x=z["x"]) ** 2
+        return inner
     est = Estimand(feature_keys=("a", "x"), m=m)
     with pytest.raises(TypeError):
         trace(est, {"a": 0, "x": 0.5})
 
 
 def test_non_linearform_return_raises():
-    def m(z, alpha):
-        return "not a linear form"
+    def m(alpha):
+        def inner(z):
+            return "not a linear form"
+        return inner
     est = Estimand(feature_keys=("a", "x"), m=m)
     with pytest.raises(TypeError, match="LinearForm"):
         trace(est, {"a": 0, "x": 0.5})
 
 
 def test_zero_scalar_return_yields_empty():
-    def m(z, alpha):
-        return 0
+    def m(alpha):
+        def inner(z):
+            return 0
+        return inner
     est = Estimand(feature_keys=("a", "x"), m=m)
     assert trace(est, {"a": 0, "x": 0.5}) == []


### PR DESCRIPTION
## Summary

Curries the user-supplied `m` from `m(z, alpha)` to `m(alpha)(z)`, so the Python convention matches the operator notation already canonicalized in the [rieszreg-notation skill](.claude/skills/rieszreg-notation/SKILL.md) and used throughout the docs (e.g. [docs/intro.qmd](docs/intro.qmd)). The recent notation-pass PR (#15) updated the factory *docstrings* to `m(α)(z)` form; this PR makes the actual code shape match.

`m` is now an operator: it takes a candidate `alpha` and returns a function of the row `z`. `Estimand.__call__` follows the same shape. The `trace` body becomes `m(Tracer())(z)`. Tracer-based linearity checking is unchanged. The public surface `trace(estimand, z) -> [(coef, point)]` and `build_augmented(rows, estimand)` keep their signatures, so backends are unaffected.

## Files changed

- `rieszreg/python/rieszreg/estimands/base.py` — six built-in factories rewritten in curried form; `Estimand.__call__` curried; module docstring updated.
- `rieszreg/python/rieszreg/estimands/tracer.py` — `trace` body, module docstring, `Tracer` class docstring.
- `rieszreg/python/rieszreg/estimator.py` — one docstring line.
- `rieszreg/python/tests/{test_tracer,test_estimand_factories,test_augmentation}.py` — fixtures and comments curried.

## Coordinated impl-package PRs

Each impl-package's custom-`m` test fixtures used the old uncurried signature and need the same curry. Mergeable independently after this PR lands:

- krrr — [rieszreg/krrr#2](https://github.com/rieszreg/krrr/pull/2)
- forestriesz — [rieszreg/forestriesz#2](https://github.com/rieszreg/forestriesz/pull/2)
- riesznet — [rieszreg/riesznet#2](https://github.com/rieszreg/riesznet/pull/2)

(rieszboost's curry already shipped via [9a0ff91](https://github.com/rieszreg/rieszboost/commit/9a0ff91).)

## Test plan

- [x] `pytest rieszreg/python/tests` — 77/77 passing locally.
- [ ] CI on this PR.
- [ ] Coordinated CI on the three impl-package PRs once each is rebased onto a rieszreg version that includes this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)