### PR TITLE
Install causaldata, xgboost, rsample for docs CI

### DIFF
--- a/.claude/skills/rieszreg-dev-environment/SKILL.md
+++ b/.claude/skills/rieszreg-dev-environment/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: rieszreg-dev-environment
+description: Operational rules for running tests, rendering docs, or executing code in the rieszreg meta-project. Triggers when running `pytest` across multiple packages, `quarto render` on the docs site, R parity tests, or anything that crosses package boundaries (rieszreg + rieszboost / krrr / forestriesz / riesznet). Especially important inside `.claude/worktrees/*` — worktrees of the rieszreg repo are NOT self-contained.
+---
+
+# rieszreg dev-environment rules
+
+## Worktrees miss the sibling impl packages
+
+The `rieszreg/` repo is one of **five sibling git repos** living under `/Users/aschuler/Desktop/RieszReg/`:
+
+```
+RieszReg/                  ← container, not a git repo
+├── rieszreg/              ← the repo this worktree is of
+├── rieszboost/            ← sibling repo
+├── krrr/                  ← sibling repo
+├── forestriesz/           ← sibling repo
+├── riesznet/              ← sibling repo
+├── docs/                  ← Quarto site (depends on ALL packages above)
+└── .venv/                 ← shared editable installs of all five
+```
+
+A `git worktree` of `rieszreg` only contains the `rieszreg/` files. The siblings (`rieszboost/`, `krrr/`, `forestriesz/`, `riesznet/`) are **not** in the worktree — they're separate git repos that happen to live next to the main `rieszreg/` checkout.
+
+CI works because `.github/workflows/docs.yml` and `.github/workflows/test.yml` use `actions/checkout` to clone each sibling into the workspace. Locally, the worktree does not.
+
+## What this breaks inside a worktree
+
+| Operation | Works in worktree? | Notes |
+|---|---|---|
+| `pytest rieszreg/python/tests` | ✓ | Only needs rieszreg itself |
+| `pytest rieszboost/python/tests` (or krrr / forestriesz / riesznet) | ✗ | Sibling dir doesn't exist |
+| `quarto render docs/` | ✗ | `docs/_setup.qmd` calls `pkgload::load_all("../rieszboost/r/rieszboost")` — fails on `pkgload_no_desc` |
+| Editing `docs/*.qmd` content | ✓ | Editing is fine; rendering is not |
+| Editing notation across all packages | ✗ | Worktree only sees rieszreg |
+| Running R parity tests for any impl package | ✗ | `pkgload::load_all` of sibling fails |
+
+## How to handle each case
+
+**Need to render docs locally** (e.g. to verify a `_freeze` cache regeneration or test a new doc page):
+
+→ Render from the main checkout at `/Users/aschuler/Desktop/RieszReg/`, not the worktree. Copy your edited `.qmd` over, render, then revert. Or: ask the user to `git pull` the main checkout to your branch's commit and render there.
+
+**Need to test a sibling package** (rieszboost, krrr, forestriesz, riesznet):
+
+→ Run from `/Users/aschuler/Desktop/RieszReg/<package>/` directly, not from the worktree. The shared `.venv` at `/Users/aschuler/Desktop/RieszReg/.venv/` has editable installs of all five packages.
+
+**Need to make a cross-cutting change** (e.g. renaming `LinearFormEstimand` → `FiniteEvalEstimand` requires updates in rieszreg + every impl package):
+
+→ Worktree handles only the rieszreg side. The impl-package changes need synchronized PRs in their own repos. Plan them as parallel PRs from the start. CI in `rieszreg` runs against `main` of the sibling repos by default — coordinate the merge order so siblings land first.
+
+## Sanity-check before claiming a local verification worked
+
+Before reporting "I verified locally", confirm the operation didn't silently fall back to a no-op:
+
+- `quarto render`: did chunks actually execute, or did `_freeze` absorb them? Check with `ls docs/_freeze/<page>/` timestamps.
+- Sibling-package test: did pytest collect tests, or did the directory not exist? Check the test count.
+- R parity test: did `pkgload::load_all` succeed, or did it abort early?
+
+If the worktree environment can't run the verification, **say so explicitly** — don't pretend the fix is verified. Push to a branch and let CI verify, or render from the main checkout.
+
+## The `.venv`
+
+The single Python venv at `/Users/aschuler/Desktop/RieszReg/.venv/` has editable installs of all five packages plus dev/doc deps (matplotlib, pandas, causaldata, xgboost, jax, etc.). When checking whether a Python module is available locally, use:
+
+```sh
+/Users/aschuler/Desktop/RieszReg/.venv/bin/python -c "import <module>"
+```
+
+The shared venv is **not** present inside `.claude/worktrees/<name>/`. Always reference it by absolute path.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,7 @@ jobs:
           if [ -d krrr/python ]; then pip install -e krrr/python; fi
           if [ -d forestriesz/python ]; then pip install -e forestriesz/python; fi
           if [ -d riesznet/python ]; then pip install -e riesznet/python; fi
-          pip install matplotlib pandas
+          pip install matplotlib pandas causaldata
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -76,6 +76,8 @@ jobs:
             any::reticulate
             any::R6
             any::pkgload
+            any::xgboost
+            any::rsample
           working-directory: rieszreg/r/rieszreg
 
       - name: Point reticulate at the project Python


### PR DESCRIPTION
## Summary

- The most recent docs build failed on `ModuleNotFoundError: No module named 'causaldata'` while re-rendering `docs/estimation/custom.qmd`. The freeze cache had been invalidated by a markdown-only edit in #21, forcing Quarto to re-execute the chunks.
- Add `causaldata` to the Python pip install and `xgboost` + `rsample` to the R deps in `.github/workflows/docs.yml`. With these in place the docs build is self-sufficient — future prose edits to `custom.qmd` or `estimands.qmd` won't silently re-break CI when the freeze cache misses.
- Also add `.claude/skills/rieszreg-dev-environment/SKILL.md` recording that `git worktree`s of `rieszreg` don't include the sibling impl repos (rieszboost / krrr / forestriesz / riesznet), which is why local doc renders from a worktree fail in confusing ways.

## Test plan

- [ ] Merge to `main` and watch the `Render and deploy unified docs` workflow finish successfully (the workflow only runs on `push: main`, not on PR).
- [ ] Confirm the `gh-pages` deploy contains a fresh `estimation/custom.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)