### PR TITLE
Tidy stale X-as-predictor-matrix prose remnants

### DIFF
--- a/rieszreg/DESIGN.md
+++ b/rieszreg/DESIGN.md
@@ -205,7 +205,7 @@ This is the contract every implementation package must meet. Section structure f
 
 ### 1.1 Estimands
 - **[from rieszreg]** Import the abstract `Estimand` base, the concrete `FiniteEvalEstimand` subclass, and the five built-in factories (`ATE`, `ATT`, `TSM(level)`, `AdditiveShift(delta)`, `LocalShift(delta, threshold)`). All factories return `FiniteEvalEstimand`. Reference: [base.py](rieszreg/python/rieszreg/estimands/base.py). `StochasticIntervention` previously appeared here; it is currently stubbed (raises `NotImplementedError`) and will be reintroduced.
-- **[from rieszreg]** Support custom estimands via user-supplied `m(alpha)(z, y) -> LinearForm` wrapped in a `FiniteEvalEstimand`. Do not bypass the tracer; linearity violations must raise. The per-row outcome `y` flows in sklearn-style: separate from `X` everywhere. `m`'s inner closure declares `def inner(z, y=None)`; built-ins ignore the second arg.
+- **[from rieszreg]** Support custom estimands via user-supplied `m(alpha)(z, y) -> LinearForm` wrapped in a `FiniteEvalEstimand`. Do not bypass the tracer; linearity violations must raise. The per-row outcome `y` flows in sklearn-style: separate from `Z` everywhere. `m`'s inner closure declares `def inner(z, y=None)`; built-ins ignore the second arg.
 - **[from rieszreg]** `trace()`, `build_augmented()`, and `RieszEstimator.fit()` accept only `FiniteEvalEstimand`. The base `Estimand` class is reserved for future subclasses outside the finite-evaluation algebra.
 - **[from rieszreg]** Honor the partial-parameter distinction (ATT and LocalShift fit partial representers; full ATT/LASE require delta-method downstream). Document this in any examples.
 - **[design rule]** If a new estimand factory belongs in the family at large, contribute it back to `rieszreg.estimands`, not to your package. A learner package never owns an `Estimand` factory.
@@ -218,7 +218,7 @@ This is the contract every implementation package must meet. Section structure f
 ### 1.3 Identification / debiasing
 - **[from rieszreg]** `LinearForm` tracer ([tracer.py](rieszboost/python/rieszboost/tracer.py)) and `build_augmented` / `AugmentedDataset` ([augmentation.py](rieszboost/python/rieszboost/augmentation.py)) are inherited. Do not reimplement.
 - **[design rule]** Sample-splitting and cross-fitting use sklearn's `cross_val_predict`. Do not introduce a bespoke `crossfit()` function.
-- **[design rule]** `score(X)` returns `−mean(per-row Riesz loss)` (sklearn "higher is better").
+- **[design rule]** `score(Z)` returns `−mean(per-row Riesz loss)` (sklearn "higher is better").
 
 ### 1.4 Diagnostics
 - **[from rieszreg]** Inherit the base `Diagnostics` dataclass and the `diagnose(...)` function. Reference: [diagnostics.py](rieszboost/python/rieszboost/diagnostics.py).
@@ -300,9 +300,9 @@ This is the contract every implementation package must meet. Section structure f
 ## 4. R / Python parity
 
 - **[design rule]** Python is primary; R is a thin reticulate wrapper.
-- **[design rule]** R6 class API: `<Pkg>Estimator$new(...)$fit(X, y)$predict(X)$score(X)$diagnose(X)`. NOT functional `fit_riesz()` shims. `X` is a feature data.frame; `y` is a separate numeric outcome vector (sklearn convention).
+- **[design rule]** R6 class API: `<Pkg>Estimator$new(...)$fit(Z, y)$predict(Z)$score(Z)$diagnose(Z)`. NOT functional `fit_riesz()` shims. `Z` is a predictor data.frame (treatment + covariates, in `feature_keys` order); `y` is a separate numeric outcome vector (sklearn convention).
 - **[from rieszreg]** Subclass `rieszreg::RieszEstimatorR6`. Bake your backend / defaults via `initialize()`. Goal: ~50 lines per package R wrapper.
-- **[from rieszreg]** Inherit `df_to_py()` to convert the X data.frame to a pandas DataFrame.
+- **[from rieszreg]** Inherit `df_to_py()` to convert the predictor data.frame `Z` to a pandas DataFrame.
 - **[from rieszreg]** Estimand and loss factories are exposed from rieszreg's R package; expose your backend-specific factories on top.
 - **[design rule]** No R-side custom `m()`. The `LinearForm` tracer is Python-only by design. R users needing custom functionals write `m()` in Python and call from R via reticulate.
 - **[your package]** Add `r/<pkg>/tests/testthat/test-parity.R` confirming bitwise-identical predictions Python ↔ R.

--- a/rieszreg/python/rieszreg/estimands/base.py
+++ b/rieszreg/python/rieszreg/estimands/base.py
@@ -12,7 +12,7 @@ and (2) the opaque `m(alpha)(z, y)` operator itself.
 `m` is an operator: it takes a candidate function `alpha` and returns a function
 of the row `z` and the per-row outcome `y`. The orchestrator calls
 `m(alpha)(z, y)` row-by-row, passing a `Tracer` for `alpha` to extract the
-linear-form structure. `Y` flows in sklearn-style: separate from `X` at every
+linear-form structure. `Y` flows in sklearn-style: separate from `Z` at every
 layer (no outcome column inside the row dict). When the user's `m` doesn't read
 `y` (the case for every built-in), the inner closure ignores its second arg.
 """

--- a/rieszreg/r/rieszreg/R/rieszreg.R
+++ b/rieszreg/r/rieszreg/R/rieszreg.R
@@ -44,9 +44,9 @@ use_python_rieszreg <- function(python = NULL, required = TRUE) {
 
 #' Convert an R data.frame to a pandas DataFrame.
 #'
-#' Numeric columns flow through unchanged. Use this on the X side of
-#' `fit(X, y)` calls; the outcome `y` is passed separately as a numeric
-#' vector.
+#' Numeric columns flow through unchanged. Use this on the predictor
+#' data.frame `Z` of `fit(Z, y)` calls; the outcome `y` is passed
+#' separately as a numeric vector.
 #'
 #' @param data An R data.frame.
 #' @return A pandas DataFrame (Python object, `convert = FALSE`).


### PR DESCRIPTION
## Summary

The X→Z rename in b7578b9 updated function signatures consistently, but a handful of prose mentions still referred to `X` as the predictor matrix. This PR updates those to `Z`:

- `rieszreg/DESIGN.md` — `score(X)` → `score(Z)`, the R6 API one-liner, the `df_to_py` description, and the "separate from X everywhere" note in §1.1.
- `rieszreg/python/rieszreg/estimands/base.py` — module docstring "separate from X at every layer".
- `rieszreg/r/rieszreg/R/rieszreg.R` — `df_to_py` docstring.

Math-context `X` (the covariate sub-block in `Z = (A, X)`) and version placeholders like `rieszreg>=X.Y` are left as-is.

Pure prose; no behavior change.

## Test plan
- [ ] Existing CI passes (no runtime code touched, but verifying nothing snags on the markdown / Roxygen rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)