### PR TITLE
Remove cross-package primacy language (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,28 +60,32 @@ python3 -m venv .venv
 
 ## Quickstart
 
-```python
-from rieszboost import RieszBooster
-from rieszreg import ATE
-
-booster = RieszBooster(estimand=ATE(), n_estimators=200, early_stopping_rounds=20,
-                       validation_fraction=0.2)
-booster.fit(df)
-alpha_hat = booster.predict(df)
-```
-
-Or compose explicitly:
+Pick any learner package and compose it with `RieszEstimator`:
 
 ```python
-from rieszreg import RieszEstimator, ATE, SquaredLoss
+from rieszreg import RieszEstimator, ATE
+
+# Gradient boosting
+from rieszboost.backends import XGBoostBackend
+est = RieszEstimator(estimand=ATE(), backend=XGBoostBackend())
+
+# Kernel ridge
 from krrr import KernelRidgeBackend, Gaussian
+est = RieszEstimator(estimand=ATE(), backend=KernelRidgeBackend(kernel=Gaussian()))
 
-est = RieszEstimator(
-    estimand=ATE(), loss=SquaredLoss(),
-    backend=KernelRidgeBackend(kernel=Gaussian(length_scale="median")),
-)
+# Random forest
+from forestriesz import ForestRieszBackend
+est = RieszEstimator(estimand=ATE(), backend=ForestRieszBackend(n_estimators=500))
+
+# Neural network
+from riesznet import TorchBackend
+est = RieszEstimator(estimand=ATE(), backend=TorchBackend(epochs=200))
+
 est.fit(df)
+alpha_hat = est.predict(df)
 ```
+
+Each learner package also ships a convenience subclass (`RieszBooster`, `KernelRieszRegressor`, `ForestRieszRegressor`, `RieszNet`) with backend-specific hyperparameters on the constructor. See the [backends comparison](https://rieszreg.github.io/rieszreg/backends/) to choose.
 
 ## Status
 

--- a/rieszreg/DESIGN.md
+++ b/rieszreg/DESIGN.md
@@ -5,7 +5,7 @@ This document does two things:
 1. **Part A** designs a shared meta-package — `rieszreg`, in the spirit of sklearn — that holds every cross-cutting abstraction so each implementation package depends on it instead of duplicating code or cross-importing.
 2. **Part B** is the detailed checklist + design directive that a new "learner" implementation package (rieszboost, krrr, future) MUST follow to plug into the ecosystem.
 
-Two packages exist today: `rieszboost` (gradient boosting; the most-developed) and `krrr` (kernel ridge; depends on rieszboost for shared abstractions). More packages are planned.
+Four learner packages exist today: `rieszboost` (gradient boosting), `krrr` (kernel ridge), `forestriesz` (random forests), and `riesznet` (neural networks). Each depends only on `rieszreg`.
 
 Reference paper: Lee & Schuler 2025 ([arXiv:2501.04871](https://arxiv.org/abs/2501.04871)). Part A moves the shared `reference/` to the meta-project level.
 

--- a/rieszreg/python/rieszreg/backends/base.py
+++ b/rieszreg/python/rieszreg/backends/base.py
@@ -146,7 +146,8 @@ def load_predictor(kind: str, dir_path, *, base_score, loss, best_iteration):
     if kind not in _PREDICTOR_LOADERS:
         raise ValueError(
             f"No loader registered for predictor kind {kind!r}. "
-            f"Import the implementation package (e.g. `import rieszboost`) "
+            f"Import a learner package (e.g. `import rieszboost`, `import krrr`, "
+            f"`import forestriesz`, `import riesznet`) "
             f"before calling .load(...). Registered kinds: {sorted(_PREDICTOR_LOADERS)}."
         )
     return _PREDICTOR_LOADERS[kind](


### PR DESCRIPTION
## Summary

Addresses [issue #9](https://github.com/rieszreg/rieszreg/issues/9): the docs, code, and READMEs gave rieszboost rhetorical primacy and the learner packages cross-referenced each other as "sister packages". Each learner package should only reference rieszreg.

This PR is one of five — corresponding PRs in rieszboost, krrr, forestriesz, and riesznet remove the cross-references on each side.

## Changes in this repo

- `rieszreg/DESIGN.md`: outdated "Two packages exist today: rieszboost (the most-developed) and krrr" replaced with accurate four-package list, each depending only on rieszreg.
- `rieszreg/python/rieszreg/backends/base.py`: `load_predictor` error message now lists all four learner packages instead of only rieszboost.
- `README.md`: quickstart restructured. Was a rieszboost-first convenience-class example with krrr as an afterthought; now leads with the `RieszEstimator` + compose-explicitly pattern showing all four backends symmetrically.

## Test plan

- [x] No code semantics changed; only prose / error-message text / quickstart code in README.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)