### PR TITLE
Handle xgboost+torch libomp coexistence in one process

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -46,6 +46,7 @@ website:
           - estimation/index.qmd
           - estimation/custom.qmd
           - estimation/external.qmd
+      - troubleshooting.qmd
       - developing.qmd
       - related.qmd
       - references.qmd

--- a/docs/install.qmd
+++ b/docs/install.qmd
@@ -33,6 +33,17 @@ brew install libomp
 
 Linux distributions (and GitHub Actions ubuntu-latest) ship `libgomp1`; no extra step is needed. `krrr` has no system prerequisites; an optional GPU backend uses [`falkon`](https://falkonml.github.io/falkon/) (`pip install -e 'krrr/python[falkon]'`). `forestriesz` depends on `econml`, which ships prebuilt wheels for macOS arm64+x86_64 and ubuntu — no compiler required. `riesznet` depends on `torch>=2.0`; CPU wheels are fetched automatically, GPU wheels need a `--index-url` per the PyTorch install matrix.
 
+### Combining `rieszboost` and `riesznet` in one process
+
+The macOS pip wheels for `xgboost` and `torch` each bundle their own `libomp.dylib`. When both are loaded into one Python process, the two OpenMP runtimes can deadlock during a fit ([troubleshooting](troubleshooting.qmd)). Two install paths avoid this:
+
+- **conda-forge** — installs `xgboost` and `pytorch` against a single shared `llvm-openmp`, so the conflict cannot occur:
+  ```sh
+  conda install -c conda-forge xgboost pytorch
+  pip install -e rieszreg/python rieszboost/python riesznet/python
+  ```
+- **pip + thread-limit env vars** — keep the pip install above and set `OMP_NUM_THREADS=1` (and `MKL_NUM_THREADS=1`) in the shell or at the top of every script that uses both backends. See the [troubleshooting page](troubleshooting.qmd) for the full discussion and options including `threadpoolctl.threadpool_limits` for finer-grained control.
+
 ### Verify
 
 The chunks below import each package and exercise its public entry point. Failure to import or instantiate raises immediately.

--- a/docs/troubleshooting.qmd
+++ b/docs/troubleshooting.qmd
@@ -1,0 +1,96 @@
+---
+title: "Troubleshooting"
+---
+
+## OpenMP deadlock when both rieszboost and riesznet are loaded
+
+### Symptom
+
+A fit hangs indefinitely. Sampling the Python process with `py-spy dump` (or attaching with `lldb`) shows the main thread stuck in OpenMP barrier code:
+
+```
+__kmp_join_barrier
+  kmp_flag_64<false, true>::wait
+    __kmp_suspend_64
+      _pthread_cond_wait
+        __psynch_cvwait
+```
+
+The same hang appears under R when `riesznet` runs through reticulate, and from RStudio / Jupyter / `quarto render` sessions that fit both backends in one process. The hang is non-deterministic: the same script may finish on one run and hang on the next.
+
+### Cause
+
+xgboost's macOS pip wheel (which `rieszboost` uses) and PyTorch's macOS pip wheel (which `riesznet` uses) each ship their own copy of `libomp.dylib`. When both packages are loaded into the same Python process, dyld maps two distinct OpenMP runtimes into the address space. Their threadpool barriers can race, leading to the deadlock above.
+
+This is an upstream xgboost + PyTorch + macOS-wheel issue, not specific to `rieszreg`. See [pytorch/pytorch#44282](https://github.com/pytorch/pytorch/issues/44282), [pytorch/pytorch#98836](https://github.com/pytorch/pytorch/issues/98836), and [dmlc/xgboost#11500](https://github.com/dmlc/xgboost/issues/11500). The same underlying conflict can throttle threads silently on Linux pip installs without producing a deadlock.
+
+The deadlock is not guaranteed: many users who load both packages never see it. The trigger is OMP-parallel work in both runtimes during the same fit.
+
+### What `rieszreg` does automatically
+
+On import, `rieszreg/__init__.py` mirrors `sklearn/__init__.py`:
+
+```python
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
+os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
+```
+
+This stops the second runtime from aborting on `OMP: Error #15` and avoids a `fork()` crash from the Intel OpenMP 2019.5 bug. `setdefault` means a value the user already exported wins.
+
+These two flags do **not** prevent the threadpool deadlock above. That requires limiting OMP threads.
+
+`rieszboost` and `riesznet` defer their `import xgboost` and `import torch` until the first attribute access, so `import rieszboost; import riesznet` (without instantiating estimators from both) does not load both `libomp` copies.
+
+When `RieszEstimator.fit()` runs and detects both `torch` and `xgboost` already loaded, it emits a one-time `RuntimeWarning` describing the situation.
+
+### Fixing the deadlock
+
+The env vars that prevent the deadlock are read by the OpenMP runtime when `libomp` is first loaded. Setting them after `import torch` or `import xgboost` is too late. So all three workarounds below assume a fresh Python process.
+
+**Option 1 — set `OMP_NUM_THREADS=1` in the shell:**
+
+```sh
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+python my_script.py
+```
+
+**Option 2 — set in Python before the imports:**
+
+```python
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
+# only after the env is set:
+import rieszboost, riesznet
+```
+
+This is the form used at the top of `index.qmd` and `tuning-and-cross-fitting.qmd` in this user guide.
+
+**Option 3 — limit threads at fit time with `threadpoolctl`:**
+
+`threadpoolctl` is a sklearn dependency and is already installed. It manages thread counts on already-loaded OMP runtimes:
+
+```python
+from threadpoolctl import threadpool_limits
+
+with threadpool_limits(limits=1):
+    booster.fit(df)
+    net.fit(df)
+```
+
+This is the right tool when only one fit (or one pipeline stage) needs to run single-threaded.
+
+**Option 4 — install via conda-forge:**
+
+conda-forge enforces a single shared `llvm-openmp` runtime across all packages in the environment via `_openmp_mutex`. The conflict cannot occur:
+
+```sh
+conda install -c conda-forge xgboost pytorch
+pip install -e rieszreg/python rieszboost/python riesznet/python
+```
+
+### Performance cost
+
+`OMP_NUM_THREADS=1` disables OpenMP intra-op parallelism for both xgboost and torch. On the dataset sizes typical for Riesz regression (`n` in the thousands to low hundreds of thousands), the cost is small — xgboost's tree construction is the dominant work and parallelizes across rows in chunks where SIMD already covers most of the speedup. Larger workloads should prefer `threadpoolctl.threadpool_limits` so that other parts of the pipeline retain parallelism.

--- a/rieszreg/python/rieszreg/__init__.py
+++ b/rieszreg/python/rieszreg/__init__.py
@@ -11,6 +11,16 @@ orchestrator.
     est.fit(Z)
 """
 
+# Mirror sklearn's `sklearn/__init__.py`: when xgboost (rieszboost) and torch
+# (riesznet) are loaded into the same process, macOS dyld can map two distinct
+# libomp copies and abort. `setdefault` so any value the user already exported
+# wins. See https://github.com/joblib/threadpoolctl/blob/master/multiple_openmp.md
+# for background; the runtime threadpool-deadlock warning lives in `_omp.py`.
+import os as _os
+_os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
+_os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
+del _os
+
 from .augmentation import (
     AugmentedDataset,
     aug_grad_eta,

--- a/rieszreg/python/rieszreg/_omp.py
+++ b/rieszreg/python/rieszreg/_omp.py
@@ -1,0 +1,47 @@
+"""Runtime detection of multi-backend OpenMP coexistence."""
+
+from __future__ import annotations
+
+import sys
+import warnings
+
+
+_WARNED = False
+
+
+def warn_if_multi_backend_omp() -> None:
+    """Emit a one-time `RuntimeWarning` if both `torch` and `xgboost` are loaded.
+
+    The condition (both libomp-shipping wheels mapped into one process) is
+    necessary but not sufficient for the threadpool deadlock — many users
+    who load both never observe a hang. Recovery (set `OMP_NUM_THREADS=1`
+    pre-import, or `threadpoolctl.threadpool_limits(1)` around the fit, or
+    a conda-forge install) requires the user to act, so the orchestrator
+    surfaces the situation rather than silently throttling threads.
+    """
+    global _WARNED
+    if _WARNED:
+        return
+    if "torch" not in sys.modules or "xgboost" not in sys.modules:
+        return
+    _WARNED = True
+    warnings.warn(
+        "Both torch (riesznet) and xgboost (rieszboost) are loaded in this "
+        "Python process. macOS pip wheels for these libraries each ship their "
+        "own copy of libomp.dylib; when both are mapped into one process, "
+        "OMP-parallel work can deadlock non-deterministically. The symptom "
+        "is a stuck fit with main-thread frames in __kmp_join_barrier. Linux "
+        "pip wheels can similarly throttle threads silently. The hang is not "
+        "guaranteed; many users who load both never see it.\n"
+        "\n"
+        "If you do hit it, restart Python and pick one:\n"
+        "  - set OMP_NUM_THREADS=1 (and MKL_NUM_THREADS=1) in the shell or "
+        "via os.environ BEFORE importing rieszboost / riesznet / torch / "
+        "xgboost (env vars are read at libomp load and ignored after);\n"
+        "  - wrap the fit in `with threadpoolctl.threadpool_limits(1):`;\n"
+        "  - install via conda-forge, which pins one shared OpenMP runtime.\n"
+        "\n"
+        "See the troubleshooting page in the user guide for details.",
+        RuntimeWarning,
+        stacklevel=3,
+    )

--- a/rieszreg/python/rieszreg/estimator.py
+++ b/rieszreg/python/rieszreg/estimator.py
@@ -17,6 +17,7 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import train_test_split
 
+from ._omp import warn_if_multi_backend_omp
 from .augmentation import aug_loss_alpha, build_augmented
 from .backends import Backend, load_predictor
 from .estimands.base import Estimand, FiniteEvalEstimand, estimand_from_spec
@@ -190,6 +191,7 @@ class RieszEstimator(BaseEstimator):
         λ-selection (when the backend uses one); pair it with `eval_y` to
         feed an outcome vector for the same rows.
         """
+        warn_if_multi_backend_omp()
         loss = self._resolved_loss()
         backend = self._resolved_backend()
 


### PR DESCRIPTION
## Summary

The macOS pip wheels for `xgboost` (rieszboost) and `torch` (riesznet) each ship their own `libomp.dylib`. When both load into one Python process, dyld maps two distinct OpenMP runtimes — the second one aborts with `OMP: Error #15`, or OMP barriers can deadlock during parallel work, hanging the fit inside `__kmp_join_barrier`. This is an upstream issue ([pytorch/pytorch#44282](https://github.com/pytorch/pytorch/issues/44282), [pytorch/pytorch#98836](https://github.com/pytorch/pytorch/issues/98836), [dmlc/xgboost#11500](https://github.com/dmlc/xgboost/issues/11500)) with no fix in sight; conda-forge sidesteps it via \`_openmp_mutex\`, pip wheels can't.

This PR makes the family handle it the way sklearn already does in \`sklearn/__init__.py\`, plus a runtime warning and docs.

- **\`rieszreg/__init__.py\`** — set \`KMP_DUPLICATE_LIB_OK=True\` and \`KMP_INIT_AT_FORK=FALSE\` via \`os.environ.setdefault\` (mirrors \`sklearn/__init__.py\`). Suppresses the abort path. \`setdefault\` so any user-set value wins.
- **\`rieszreg/_omp.py\` + \`RieszEstimator.fit\`** — once-per-process \`RuntimeWarning\` when both \`torch\` and \`xgboost\` are detected in \`sys.modules\`. Describes the conditions under which the deadlock is likely (not guaranteed), and lists three concrete recovery paths: pre-import \`OMP_NUM_THREADS=1\`, \`threadpoolctl.threadpool_limits\`, or a conda-forge install. We deliberately do not throttle threads automatically — the deadlock is non-deterministic and \`OMP_NUM_THREADS=1\` has a real perf cost on larger fits.
- **\`docs/troubleshooting.qmd\`** (new) — indexed by the \`__kmp_join_barrier\` symptom so Google finds it. Covers symptom, cause, what rieszreg does automatically, and the four ordered recovery options.
- **\`docs/install.qmd\`** — adds a "Combining \`rieszboost\` and \`riesznet\`" subsection recommending conda-forge.
- **\`docs/_quarto.yml\`** — troubleshooting page added to the sidebar.

## Coordination

Pairs with [rieszreg/riesznet#8](https://github.com/rieszreg/riesznet/pull/8) (lazy \`import torch\`) and [rieszreg/rieszboost#8](https://github.com/rieszreg/rieszboost/pull/8) (matching README pointer). Land **those two first** — this repo's CI checks out both as siblings from \`main\`.

## Test plan

- [x] \`pytest rieszreg/python/tests\` — 84/84 passing locally.
- [x] \`pytest rieszboost/python/tests\` — 106 passing.
- [x] \`pytest riesznet/python/tests\` (with the lazy-import PR applied) — 50 passing.
- [x] \`pytest krrr/python/tests\` — 44 passing.
- [x] \`pytest forestriesz/python/tests\` — 52 passing.
- [x] Smoke: after \`import rieszreg\`, \`os.environ["KMP_DUPLICATE_LIB_OK"] == "True"\`, \`os.environ["KMP_INIT_AT_FORK"] == "FALSE"\`.
- [x] Smoke: \`import rieszboost; import riesznet\` does **not** pull torch or xgboost into \`sys.modules\` (lazy on both sides).
- [x] Smoke: \`RieszEstimator.fit()\` emits a single \`RuntimeWarning\` when both \`torch\` and \`xgboost\` are loaded; suppressed on subsequent fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)