### PR TITLE
Install riesztree in docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,13 @@ jobs:
           path: riesznet
         continue-on-error: true
 
+      - name: Checkout riesztree (sibling repo)
+        uses: actions/checkout@v4
+        with:
+          repository: rieszreg/riesztree
+          path: riesztree
+        continue-on-error: true
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -62,6 +69,7 @@ jobs:
           if [ -d krrr/python ]; then pip install -e krrr/python; fi
           if [ -d forestriesz/python ]; then pip install -e forestriesz/python; fi
           if [ -d riesznet/python ]; then pip install -e riesznet/python; fi
+          if [ -d riesztree/python ]; then pip install -e riesztree/python; fi
           pip install matplotlib pandas causaldata
 
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
## Summary

The unified docs build broke after [#30](https://github.com/rieszreg/rieszreg/pull/30) / [#31](https://github.com/rieszreg/rieszreg/pull/31) merged. CI log:

\`\`\`
[ 6/22] backends/tree.qmd
processing file: tree.qmd
ModuleNotFoundError: No module named 'riesztree'
Quitting from tree.qmd
\`\`\`

[\`docs.yml\`](.github/workflows/docs.yml) checks out and pip-installs each sibling impl package (rieszboost, krrr, forestriesz, riesznet) but was missing the matching steps for riesztree, so the riesztree page couldn't execute its Python chunks.

This PR adds the checkout step and the conditional install line, mirroring the existing pattern.

Root cause is structural: when [#27](https://github.com/rieszreg/rieszreg/pull/27) added the riesztree docs page, the corresponding CI install steps were not added. The build accidentally passed in earlier merges because the riesztree page had not yet been touched in a way that re-triggered execution against the freshly-installed venv.

## Test plan

- [ ] Watch the docs CI run on this PR — it should now reach the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)