### PR TITLE
Phase 7: rewrite CLAUDE.md and skills for the monorepo + research-code coding skill

### DIFF
--- a/.claude/skills/rieszreg-backend-contract/SKILL.md
+++ b/.claude/skills/rieszreg-backend-contract/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: rieszreg-backend-contract
+description: Checklist for adding a new learner package to the rieszreg monorepo. Use when creating a new directory under `packages/<pkg>/`, implementing `Backend.fit_augmented` or `MomentBackend.fit_rows`, registering a predictor loader, writing a convenience subclass of `RieszEstimator`, or any task framed as "wrap my learner" / "add a new backend" / "new package for the family". This skill is the triggered short form of `DESIGN.md` Part B; cite back to it for the full long-form contract.
+---
+
+# Adding a learner to the rieszreg monorepo
+
+A new learner means a new workspace member at `packages/<pkg>/`. Six items must be in place for it to fit the family.
+
+## 1. Pick the entry point
+
+Two Protocols, defined in `packages/rieszreg/python/rieszreg/backends/base.py`:
+
+- **`Backend.fit_augmented`** — augmentation-style. The orchestrator pre-computes the augmented `(a, b)` dataset; you receive it and fit. References: `XGBoostBackend` in rieszboost, `KernelRidgeBackend` in krrr, `RieszTreeBackend` in riesztree.
+- **`MomentBackend.fit_rows`** — moment-style. You receive raw rows + the estimand and call `rieszreg.trace(estimand, row)` per row to compute moments. References: `ForestRieszBackend` in forestriesz, `TorchBackend` in riesznet.
+
+Pick by the natural decomposition of your learner's loss. Boosted trees, kernel ridge, single-tree → augmented. Forests, neural nets → moments.
+
+## 2. Return shape
+
+Both Protocols return `FitResult(predictor, best_iteration, best_score, history)`. The shape is identical for both entry points; the orchestrator depends on it being uniform.
+
+## 3. Predictor + loader registration
+
+Implement a `<Pkg>Predictor` class (the thing that gets returned in `FitResult.predictor`) with `predict(Z)` and `score(Z, alpha_target)` methods. Then register a loader so `RieszEstimator.load(...)` can deserialize a previously-saved fit:
+
+```python
+# in packages/<pkg>/python/<pkg>/__init__.py or similar
+from rieszreg.backends import register_predictor_loader
+register_predictor_loader("<pkg>-kind", <Pkg>Predictor.load)
+```
+
+The loader-kind string must be unique across the family.
+
+## 4. Convenience subclass
+
+Provide a `<Pkg><Estimator>` class subclassing `rieszreg.RieszEstimator` with the learner-specific Tier-3 hyperparameters on its constructor:
+
+```python
+class RieszBooster(RieszEstimator):
+    def __init__(self, *, n_estimators=100, learning_rate=0.1, max_depth=4, ...):
+        backend = XGBoostBackend(n_estimators=n_estimators, ...)
+        super().__init__(backend=backend, ...)
+```
+
+Tier-3 knobs (learner-specific) live on this constructor only — never on `RieszEstimator` itself or on Protocol methods. See [`rieszreg-coding`](../rieszreg-coding/SKILL.md) §3.
+
+## 5. R wrapper
+
+Subclass `rieszreg::RieszEstimatorR6` for the R API:
+
+```r
+# packages/<pkg>/r/<pkg>/R/<pkg>.R
+<Pkg>Regressor <- R6::R6Class(
+  "<Pkg>Regressor",
+  inherit = rieszreg::RieszEstimatorR6,
+  public = list(
+    initialize = function(...) {
+      ...
+    }
+  )
+)
+```
+
+`DESCRIPTION` declares `Imports: R6, reticulate (>= 1.30), rieszreg (>= 0.0.1)`. The rieszreg dep resolves at test time via `pkgload::load_all`, not from CRAN. See [`rieszreg-dev-environment`](../rieszreg-dev-environment/SKILL.md) for the R parity-test pattern.
+
+## 6. Tests
+
+Two categories of test are required (DESIGN.md §7):
+
+- **Per-estimand examples** (DESIGN.md §7.1): every built-in estimand (`ATE`, `ATT`, `TSM`, `AdditiveShift`, `LocalShift`) must have a runnable script in `packages/<pkg>/python/examples/`. These double as living documentation and as smoke tests against API drift.
+- **Reference-parity test** (DESIGN.md §5.2): if your method has a prior published implementation, ship a parity test against a hand-applied reference computation on a small example. If the method is novel (no prior implementation, e.g. riesztree), ship a self-parity test against a closed-form leaf solution or an independent code path.
+
+Plus the standard sklearn-conformance test (use `rieszreg.testing.sklearn_conformance`) and recovery tests on a known DGP from `rieszreg.testing.dgps`. See [`rieszreg-coding`](../rieszreg-coding/SKILL.md) §5 for which tests are worth writing and which aren't.
+
+## 7. Workspace wire-up
+
+- `packages/<pkg>/python/pyproject.toml` — `dependencies = ["rieszreg"]` (uv resolves to the workspace member; no version pin needed inside the workspace).
+- Add `packages/<pkg>/python` to `[tool.uv.workspace] members = [...]` in the root `pyproject.toml`.
+- Add `<pkg>` to the matrix in `.github/workflows/test.yml` and `release.yml`.
+- Run `uv sync --all-packages --all-extras` to install the new member into the workspace `.venv`.
+- Add a backend page to `docs/backends/<pkg>.qmd` showing a worked example with the bilingual Python/R panel-tabset.
+
+## 8. Where the contract is canonical
+
+`DESIGN.md` Part B at the repo root is the long-form authoritative version. This skill is the triggered short form. If they ever conflict, `DESIGN.md` wins; update this skill.

--- a/.claude/skills/rieszreg-coding/SKILL.md
+++ b/.claude/skills/rieszreg-coding/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: rieszreg-coding
+description: How to write code in the rieszreg monorepo — research-code mindset, OOP-first organization, Tier-1/2/3 placement across packages, sklearn-first patterns, and test philosophy (test what the library does statistically, not that warnings fire). Use whenever you are about to add or modify code under `packages/<pkg>/python/<pkg>/`, write tests, design new abstractions, or make planning decisions about where new functionality should live.
+---
+
+# Coding in the rieszreg monorepo
+
+This skill encodes the recurring style and architecture decisions for this codebase. Apply on every code edit. The five concerns below interact — a single new method usually touches three of them.
+
+## 1. Research code, not production code
+
+This is research code that supports active development of statistical methods. The maintenance posture is different from a stable production library:
+
+- **Breaking changes are fine.** A rename, a signature change, a removal — any of those land as a single commit. Don't write deprecation shims. Don't keep old kwargs as aliases. Don't preserve old API names "in case someone is using them" — the only people using them will rebase or update.
+- **Don't paranoidly validate user inputs.** Internal calls trust their callers. Validation happens at the genuine boundary (the public `RieszEstimator.fit` entry point, file I/O, deserialization). Inside the codebase, a function that takes an `Estimand` trusts that it received an `Estimand`.
+- **Don't add error handling, fallbacks, or retries for scenarios that can't happen.** If a code path can only be reached via an internal call site that always passes valid data, don't write defensive checks. Trust the framework guarantees (sklearn, numpy, torch).
+- **Don't gate features behind backwards-compat flags.** If a new fit signature is better, change it. Update every call site in the same commit.
+
+Production-style hygiene that *is* worth keeping: type hints on public functions, docstrings on public classes, a clear sklearn-conformant API surface. Production-style hygiene that is *not* worth keeping: deprecation warnings, FutureWarnings about future renames, version-gated behavior, exhaustive input validation.
+
+## 2. OOP-first; extend existing classes; fewer lines is better
+
+Default to extending an existing class when a new piece of functionality conceptually belongs there. Reach for a new module or a free function only when the new functionality is genuinely orthogonal to existing classes.
+
+Concrete heuristics:
+
+- **New per-loss behavior** → method on `Loss` (`packages/rieszreg/python/rieszreg/losses/base.py`). Not a `compute_X(loss, ...)` free function elsewhere.
+- **New per-estimand behavior** → method on `Estimand` (`packages/rieszreg/python/rieszreg/estimands/base.py`).
+- **New per-backend behavior** → method on `Backend` / `MomentBackend` Protocol or on the concrete `<Pkg>Backend` class.
+- **New diagnostic** → field on the per-package `Diagnostics` dataclass.
+- **New shared helper** that several backends would use → in `rieszreg`, not in any one impl package.
+
+When tempted to add a new file with a new free function, pause and ask: *which existing class would naturally own this method?* If the answer is "this class, but it doesn't have that method yet," add the method.
+
+**Prefer fewer lines to more.** A 6-line method that does the thing is better than a 22-line method that does the thing with three intermediate-named locals and a docstring repeating the function name. Don't expand `return self._loss.tilde_potential(alpha) - m_alpha` into a 12-line block to "explain" it.
+
+When writing a *plan* (in conversation or in a plan file), explicitly think through: *which existing abstractions do I extend?* not just *which new file do I create?* If the plan introduces a new top-level concept (a new Protocol, a new dataclass), that's a real architectural move and should be justified. If it doesn't, the plan should fit into existing files.
+
+## 3. Tier-1 / Tier-2 / Tier-3 placement
+
+The architectural rule from `DESIGN.md` Part A §2. Every parameter, method, or abstraction in this codebase belongs to exactly one tier:
+
+- **Tier 1 — universal across all backends.** Lives in `packages/rieszreg/`. Examples: `Estimand`, `Loss`, `RieszEstimator`, `Backend` and `MomentBackend` Protocols, `Diagnostics` base, `AugmentedDataset`. A would-be Tier-1 thing must work for *every* plausible backend the family might add. If a moment-style backend (forest, neural net) would just *ignore* the new kwarg, it isn't Tier 1.
+- **Tier 2 — orchestrator dispatch flag.** Lives on `RieszEstimator` only when it picks between Tier-1 dispatch paths (e.g. `fit_augmented` vs `fit_rows`). Rare; don't invent new ones casually.
+- **Tier 3 — learner-specific knob.** Lives on the concrete backend's constructor (`XGBoostBackend.n_estimators`, `KernelRidgeBackend.kernel`, `RieszTreeRegressor.max_depth`). Not on `RieszEstimator`, not on Protocol methods.
+
+The would-be-ignored lint test: before adding a kwarg to `RieszEstimator.__init__` or to a `Backend` Protocol method, ask *would a moment-style backend (forest, neural net) ignore this kwarg?* If yes, it's Tier 3 — move it to the concrete backend constructor.
+
+Concrete failure modes the codebase has had: `n_estimators` on `RieszEstimator` (was Tier 3), `feature_keys` on `fit()` (no, plumb through `Z` directly), custom `crossfit()` orchestration function (no, use `cross_val_predict`).
+
+## 4. sklearn-first
+
+Before writing procedural code with loops, splits, grids, or folds, ask *"is there an sklearn way?"*. If yes, use it. The estimator's user-facing API must compose with `clone`, `GridSearchCV`, `cross_val_predict`, `Pipeline` — verify those four work on every change to the orchestrator, the predictor, or any concrete `<Pkg>Backend`.
+
+Bespoke is reserved for things sklearn genuinely doesn't cover: the `LinearForm` tracer, the custom xgboost objective, the Bregman `Loss` Protocol, the augmentation engine. If you find yourself writing `for fold in folds:` with a manual `train_test_split`, that's a flag — almost certainly `cross_val_predict` does what you want in one line.
+
+## 5. Test philosophy
+
+Tests should verify the library is doing what it's *meant* to do, statistically and conceptually. Not that the right warning fires on the wrong input.
+
+**The interesting tests** (write more of these):
+
+- *Recovery*: on a known DGP where the true Riesz representer is closed-form, the estimator recovers it within Monte-Carlo error. (`testing.dgps` provides ATE, TSM, AdditiveShift DGPs with analytic ground truth.)
+- *Parity*: when there's a published method this implements, the result matches a hand-applied reference computation on a small example. (DESIGN.md §5.2.) For methods with no prior implementation, ship a self-parity test against a closed-form leaf solution or an independent code path.
+- *sklearn conformance*: `clone`, `cross_val_predict`, `Pipeline`, `GridSearchCV` compose with the new estimator. (`testing.sklearn_conformance` provides this.)
+- *Cross-loss correctness*: behavior matches across the four built-in losses, especially around link-function boundaries.
+
+**Tests not worth writing** (delete these on touch):
+
+- Defensive input validation tests: "raises if `n_estimators=0`", "raises if `Z` is None", "raises if `loss` is unrecognized".
+- Warning-firing tests: "FutureWarning when `old_param` is set". (We don't emit FutureWarnings.)
+- Backwards-compat shim tests: "old API name still works".
+- Trivial smoke tests that mirror existing higher-level tests: "import works", "constructor returns an instance".
+
+If a test you're writing only fails when someone removes a guard rail (an `if x is None: raise` block), the test is testing the guard rail, not the statistical method. Skip it.
+
+## 6. When in doubt
+
+Refer to `DESIGN.md` Part A (the meta-package architecture) and Part B (the contract every learner package satisfies). When the rules above conflict with a specific situation, favor: (a) what makes the public API clean and sklearn-conformant, (b) what makes the test suite genuinely informative about statistical correctness, (c) fewer files, fewer lines, fewer abstractions.

--- a/.claude/skills/rieszreg-cross-package-change/SKILL.md
+++ b/.claude/skills/rieszreg-cross-package-change/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: rieszreg-cross-package-change
+description: Sweep checklist for a public-API change in `packages/rieszreg/` — renames, signature changes, removals, deprecations of anything re-exported from `rieszreg/__init__.py`, the Estimand factories, the Loss Protocol, Backend / MomentBackend signatures. Use whenever a commit message starts with "rename", "refactor", "drop", "deprecate", or when modifying a public surface in `packages/rieszreg/python/rieszreg/`. The goal is to catch stale prose, examples, and docstrings in the same commit as the API change.
+---
+
+# Cross-package sweep after a rieszreg API change
+
+In the monorepo, the rename itself is a single commit (no coordinated PRs across repos). The remaining work is the *prose-and-examples sweep* — every README, every docstring, every `docs/*.qmd`, every `packages/<pkg>/python/examples/*` that mentions the old symbol. Catching this in the same commit avoids the "Tidy stale X-as-predictor-matrix prose remnants"-style follow-up PRs that used to land a week later.
+
+## The sweep
+
+```sh
+grep -rn '<old>' --include='*.py' --include='*.qmd' --include='*.md' --include='*.R' \
+  packages/ docs/ README.md DESIGN.md CLAUDE.md
+```
+
+Hit list to mentally walk through:
+
+1. **Source** of every package — `packages/<pkg>/python/<pkg>/**/*.py`, `packages/<pkg>/r/<pkg>/R/*.R`. Update call sites and docstrings.
+2. **Tests** — `packages/<pkg>/python/tests/**/*.py`, `packages/<pkg>/r/<pkg>/tests/testthat/*.R`. Update imports, fixtures, assertions.
+3. **Examples** — `packages/<pkg>/python/examples/*.py` (one per estimand, per package; DESIGN.md §7.1). Update example code and any inline comments.
+4. **READMEs** — `README.md` at root + `packages/<pkg>/README.md` for each package. Update the API description and any code blocks.
+5. **CLAUDE.md files** — root and any per-package `packages/<pkg>/CLAUDE.md`.
+6. **DESIGN.md** — at root. Cross-reference notation tables and API descriptions.
+7. **User-guide docs** — `docs/*.qmd`, especially the per-backend pages and the estimands/losses pages. The `docs/_freeze/` cache will regenerate on the next render.
+8. **The notation skill** — `.claude/skills/rieszreg-notation/SKILL.md`. If the rename has notation implications (a symbol changed, a term changed), update the canonical convention there. The rest of the codebase follows from that.
+
+## When the rename has notation consequences
+
+If you're renaming a math symbol or a domain term — e.g. `g → mu`, `theta → psi`, "target parameter" → "estimand" — the rename is bigger than a code change. Update the [`rieszreg-notation`](../rieszreg-notation/SKILL.md) skill **first**, then sweep prose to match. Doc-tone rules (also in the notation skill) apply to any prose you touch in the sweep — replace any "the workhorse" / "the natural way" / em-dash-laden phrasing while you're there.
+
+## When the rename has API consequences for downstream users
+
+This is research code (see [`rieszreg-coding`](../rieszreg-coding/SKILL.md) §1) — breaking changes are fine, no deprecation shims. The sweep is for *internal* consistency across the monorepo, not for backwards compatibility.
+
+If a downstream user (paper, downstream wrapper) is pinned to a specific tagged release, that pin keeps working — the rename only affects users on `main` or on tags after the rename. Don't add aliases or shims.
+
+## Verification
+
+After the sweep, before committing:
+
+```sh
+grep -rn '<old>' --include='*.py' --include='*.qmd' --include='*.md' --include='*.R' \
+  packages/ docs/ README.md DESIGN.md CLAUDE.md
+```
+
+Should return nothing (or only intentional historical references — e.g. a CHANGELOG entry). Then run the full test matrix locally before pushing:
+
+```sh
+for p in rieszreg rieszboost krrr forestriesz riesznet riesztree; do
+  uv run pytest packages/$p/python/tests -q
+done
+```

--- a/.claude/skills/rieszreg-dev-environment/SKILL.md
+++ b/.claude/skills/rieszreg-dev-environment/SKILL.md
@@ -1,70 +1,106 @@
 ---
 name: rieszreg-dev-environment
-description: Operational rules for running tests, rendering docs, or executing code in the rieszreg meta-project. Triggers when running `pytest` across multiple packages, `quarto render` on the docs site, R parity tests, or anything that crosses package boundaries (rieszreg + rieszboost / krrr / forestriesz / riesznet). Especially important inside `.claude/worktrees/*` — worktrees of the rieszreg repo are NOT self-contained.
+description: Operational rules for the rieszreg uv-workspace monorepo. Use when running `uv sync` or `uv run pytest`, creating or working inside a `git worktree`, rendering the Quarto docs site (`docs/`), or doing anything that touches the workspace `.venv`. Triggers any time you cd into a fresh checkout of `rieszreg/rieszreg` or one of its worktrees.
 ---
 
-# rieszreg dev-environment rules
+# rieszreg dev environment
 
-## Worktrees miss the sibling impl packages
+The repo is a single `uv` workspace at `github.com/rieszreg/rieszreg`. Six packages live under `packages/<pkg>/`. One `.venv/` at the workspace root, with all six packages editable-installed via uv. Worktrees get their own `.venv/` (one `uv sync` per worktree).
 
-The `rieszreg/` repo is one of **five sibling git repos** living under `/Users/aschuler/Desktop/RieszReg/`:
+## First-time setup
 
-```
-RieszReg/                  ← container, not a git repo
-├── rieszreg/              ← the repo this worktree is of
-├── rieszboost/            ← sibling repo
-├── krrr/                  ← sibling repo
-├── forestriesz/           ← sibling repo
-├── riesznet/              ← sibling repo
-├── docs/                  ← Quarto site (depends on ALL packages above)
-└── .venv/                 ← shared editable installs of all five
+```sh
+git clone https://github.com/rieszreg/rieszreg.git
+cd rieszreg
+uv sync --all-packages --all-extras    # creates .venv with all six pkgs editable
 ```
 
-A `git worktree` of `rieszreg` only contains the `rieszreg/` files. The siblings (`rieszboost/`, `krrr/`, `forestriesz/`, `riesznet/`) are **not** in the worktree — they're separate git repos that happen to live next to the main `rieszreg/` checkout.
+`uv` (Astral's package manager) must be installed: `brew install uv` on macOS, or `curl -LsSf https://astral.sh/uv/install.sh | sh`.
 
-CI works because `.github/workflows/docs.yml` and `.github/workflows/test.yml` use `actions/checkout` to clone each sibling into the workspace. Locally, the worktree does not.
+## Running things
 
-## What this breaks inside a worktree
+Two equivalent forms:
 
-| Operation | Works in worktree? | Notes |
-|---|---|---|
-| `pytest rieszreg/python/tests` | ✓ | Only needs rieszreg itself |
-| `pytest rieszboost/python/tests` (or krrr / forestriesz / riesznet) | ✗ | Sibling dir doesn't exist |
-| `quarto render docs/` | ✗ | `docs/_setup.qmd` calls `pkgload::load_all("../rieszboost/r/rieszboost")` — fails on `pkgload_no_desc` |
-| Editing `docs/*.qmd` content | ✓ | Editing is fine; rendering is not |
-| Editing notation across all packages | ✗ | Worktree only sees rieszreg |
-| Running R parity tests for any impl package | ✗ | `pkgload::load_all` of sibling fails |
+```sh
+uv run pytest packages/rieszreg/python/tests -q     # uv handles activation
+.venv/bin/python -m pytest packages/rieszreg/python/tests -q     # direct
+```
 
-## How to handle each case
+Use `uv run <cmd>` when in doubt — it ensures the workspace `.venv` is current before running.
 
-**Need to render docs locally** (e.g. to verify a `_freeze` cache regeneration or test a new doc page):
+For an interactive REPL on the workspace:
 
-→ Render from the main checkout at `/Users/aschuler/Desktop/RieszReg/`, not the worktree. Copy your edited `.qmd` over, render, then revert. Or: ask the user to `git pull` the main checkout to your branch's commit and render there.
+```sh
+uv run python
+```
 
-**Need to test a sibling package** (rieszboost, krrr, forestriesz, riesznet):
+## Worktrees
 
-→ Run from `/Users/aschuler/Desktop/RieszReg/<package>/` directly, not from the worktree. The shared `.venv` at `/Users/aschuler/Desktop/RieszReg/.venv/` has editable installs of all five packages.
+`git worktree add ../wt-feature feature-branch` creates a worktree. Each worktree has its own `.venv/` once you run `uv sync` inside it. From the worktree:
 
-**Need to make a cross-cutting change** (e.g. renaming `LinearFormEstimand` → `FiniteEvalEstimand` requires updates in rieszreg + every impl package):
+```sh
+cd ../wt-feature
+uv sync --all-packages --all-extras
+.venv/bin/python -c "import rieszreg; print(rieszreg.__file__)"
+# expected: <wt-feature>/packages/rieszreg/python/rieszreg/__init__.py
+```
 
-→ Worktree handles only the rieszreg side. The impl-package changes need synchronized PRs in their own repos. Plan them as parallel PRs from the start. CI in `rieszreg` runs against `main` of the sibling repos by default — coordinate the merge order so siblings land first.
+The path printed must be **inside the worktree**. If it's not — if it points to the main checkout or any other location — there is a leftover `rieszreg/` directory at the workspace root namespace-shadowing the editable install. Remove it: `rm -rf rieszreg` (the directory at the root, *not* `packages/rieszreg/`).
+
+## Adding extras you need ad-hoc
+
+The workspace pyproject has a `[dependency-groups] docs = [...]` group with matplotlib, pandas, causaldata, xgboost, jax, torch. To get those in your venv:
+
+```sh
+uv sync --all-packages --all-extras --group docs
+```
+
+Other groups can be added to the root `pyproject.toml` — keep them at the workspace root, not in member pyprojects, when they're cross-cutting.
+
+## Quarto docs
+
+The unified docs site lives at `docs/` and Quarto-renders to `docs/_site/` (gitignored). The `_freeze/` cache **is** committed — that's what lets the gh-pages publish workflow skip re-executing chunks.
+
+```sh
+quarto render docs/                       # full site (10+ minutes)
+quarto render docs/<page>.qmd             # single page
+```
+
+If a render seems stuck, check whether chunks actually executed:
+
+```sh
+ls -lt docs/_freeze/<page>/execute-results/   # most-recently-modified files
+```
+
+If the timestamps are old, the chunks haven't run and Quarto is using the cache. To force fresh execution: delete the relevant `_freeze/<page>/` and re-render.
+
+To kill a stuck render and any orphan chunk processes:
+
+```sh
+pkill -f "quarto render"
+ps -ef | grep -E '(quarto|knitr|R --slave|python.*chunk)' | grep -v grep
+```
+
+## R parity tests
+
+R uses the workspace's Python venv via reticulate. Run from the workspace root:
+
+```sh
+uv run Rscript -e '
+  pkgload::load_all("packages/rieszreg/r/rieszreg")
+  for (p in c("rieszboost","krrr","forestriesz","riesznet","riesztree")) {
+    pkgload::load_all(file.path("packages", p, "r", p))
+    testthat::test_dir(file.path("packages", p, "r", p, "tests", "testthat"))
+  }
+'
+```
+
+R packages are *not* uv-managed — uv only handles Python. R deps come from CRAN at test time. The `rieszreg` R package isn't on CRAN; sibling R packages declare it in their `DESCRIPTION` Imports, which means `pak::pkg_deps` (used by `r-lib/actions/setup-r-dependencies`) can't resolve a sibling's deps directly. CI works around this by setting up R deps from rieszreg's DESCRIPTION (which only has CRAN deps) and relying on `pkgload::load_all` for the local rieszreg + sibling at test time.
 
 ## Sanity-check before claiming a local verification worked
 
-Before reporting "I verified locally", confirm the operation didn't silently fall back to a no-op:
+- `uv run pytest <path> -q` collected and ran the expected test count (compare with CI numbers in the workflow logs).
+- `quarto render`: did the chunks actually execute? `ls -lt docs/_freeze/<page>/` timestamps should be recent.
+- R parity test: did `pkgload::load_all` succeed and was `testthat::test_dir` actually invoked? Look for `[ FAIL 0 | … ]` or `OK` in the output.
 
-- `quarto render`: did chunks actually execute, or did `_freeze` absorb them? Check with `ls docs/_freeze/<page>/` timestamps.
-- Sibling-package test: did pytest collect tests, or did the directory not exist? Check the test count.
-- R parity test: did `pkgload::load_all` succeed, or did it abort early?
-
-If the worktree environment can't run the verification, **say so explicitly** — don't pretend the fix is verified. Push to a branch and let CI verify, or render from the main checkout.
-
-## The `.venv`
-
-The single Python venv at `/Users/aschuler/Desktop/RieszReg/.venv/` has editable installs of all five packages plus dev/doc deps (matplotlib, pandas, causaldata, xgboost, jax, etc.). When checking whether a Python module is available locally, use:
-
-```sh
-/Users/aschuler/Desktop/RieszReg/.venv/bin/python -c "import <module>"
-```
-
-The shared venv is **not** present inside `.claude/worktrees/<name>/`. Always reference it by absolute path.
+If the worktree environment can't run a verification, say so explicitly — don't pretend the fix is verified. Push to a feature branch and let CI verify.

--- a/.claude/skills/rieszreg-notation/SKILL.md
+++ b/.claude/skills/rieszreg-notation/SKILL.md
@@ -69,7 +69,7 @@ Concretely:
 
 - This skill (canonical reference). Update here first if the conventions ever change.
 - [`CLAUDE.md`](../../CLAUDE.md) (cross-reference at the top, so anyone working in the repo is reminded).
-- [`rieszreg/DESIGN.md`](../../rieszreg/DESIGN.md) (cross-reference under a "Notation" section).
+- [`DESIGN.md`](../../DESIGN.md) (cross-reference under a "Notation" section).
 
 ## 10. Drift handling
 
@@ -110,3 +110,18 @@ In code, the same three concepts are spelled out as descriptive method names on 
 - `tilde_potential(alpha)` ↔ $\tilde h(\alpha)$
 
 Don't use Greek letters (e.g. $\phi$, $\psi$) for the potential or its derivatives anywhere — Greek letters in this codebase denote functionals of distributions ($\mu$ for the conditional mean, $\alpha$ for the Riesz representer, $\psi$ for the estimand), not arbitrary scalar functions.
+
+## 14. Doc-tone (banned phrases and patterns)
+
+User-facing docs describe what's currently in the package, in plain instructive prose matching the [ngboost user guide](https://stanfordmlgroup.github.io/ngboost/intro.html). The pre-commit hook (`.githooks/pre-commit`) checks for two failure modes; this section is what it enforces.
+
+1. **No design-decision metacommentary.** Don't explain the API's negative space — what we removed, intentionally didn't build, or chose between. Just describe what the function does and how to use it. "Defaults to early stopping with a 10% validation split" is good. "We chose 10% rather than 20% because…" is not. "Originally `feature_keys` was used, but…" is not.
+2. **No AI-flavored hedge or editorial framing.** Banned phrases (non-exhaustive, but indicative): "the workhorse", "the right choice for almost every", "almost never needs tuning", "the natural way/API", "rather than reinvent", "out-of-the-box", "best-in-class", "a common pattern". Avoid em-dashes peppered through prose. Sentences should be short (8–15 words on average), active voice. "X computes Y" beats "X is the function that computes Y".
+
+These rules apply to `docs/*.qmd`, every `README.md`, all docstrings, and code comments. They do *not* apply to `DESIGN.md`, this skill, or other contributor-facing internal docs — those can have whatever tone makes the architectural decisions clear.
+
+## 15. Living-doc rule
+
+Every public-API change updates `README.md` and the relevant `docs/*.qmd` page **in the same commit**. A new estimand, a new hyperparameter, a new diagnostic, a new loss — the user-facing pages must reflect the change at the moment of the change, not in a follow-up "doc update" PR.
+
+The pre-commit hook does not enforce this directly (it can't know what counts as "public-API"), but it *is* enforced by code review and by the [`rieszreg-cross-package-change`](../rieszreg-cross-package-change/SKILL.md) skill's sweep. Do not split docs and code into separate commits for the same logical change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,135 +1,76 @@
-# RieszReg (meta-project)
+# RieszReg monorepo
 
-> **Read [`rieszreg/DESIGN.md`](rieszreg/DESIGN.md) first.** It is the authoritative
-> design document for the family — Part A is the meta-package architecture,
-> Part B is the contract every learner package (rieszboost, krrr, future)
-> must satisfy. Anything in this CLAUDE.md is operational notes; anything in
-> DESIGN.md is contract.
+**This is research code, not production.** Breaking changes are fine. Don't write deprecation shims, don't preserve old API names "for compatibility", don't paranoidly validate user inputs at every entry point. Tests should verify the libraries do what they're meant to do statistically and conceptually — not that warnings fire on bad input.
 
-> **Notation conventions** (math, prose, code naming) for everything across
-> this family — docs, READMEs, docstrings, comments, examples — live in the
-> [`rieszreg-notation` skill](.claude/skills/rieszreg-notation/SKILL.md).
-> Read it before editing any user-facing prose or docstring that mentions
-> $\mu$ / $\alpha$ / $\psi$ / $m$, the data tuple $Z = (A, X)$, or the term
-> "learner". Update touched paragraphs to the canonical convention; defer
-> bulk sweeps to a dedicated notation-pass PR.
+> **Read [`DESIGN.md`](DESIGN.md) first.** Authoritative architecture for the family — Part A is the meta-package, Part B is the contract every learner package must satisfy. Anything in this file is operational notes; anything in DESIGN.md is contract.
 
-A family of packages for Riesz regression. Top-level coordinator for:
+> **Skills load on the relevant edits.** Do not duplicate their content here:
+> - [`rieszreg-notation`](.claude/skills/rieszreg-notation/SKILL.md) — math/prose/code naming conventions and doc-tone rules. Triggers on user-guide prose, READMEs, docstrings, comments.
+> - [`rieszreg-coding`](.claude/skills/rieszreg-coding/SKILL.md) — Tier-1/2/3 placement, OOP-first, fewer-lines preference, sklearn-first, research-code mindset, test philosophy. Triggers on any code edit in `packages/`.
+> - [`rieszreg-dev-environment`](.claude/skills/rieszreg-dev-environment/SKILL.md) — `uv sync` workflow, worktree usage, Quarto rendering ops.
+> - [`rieszreg-backend-contract`](.claude/skills/rieszreg-backend-contract/SKILL.md) — checklist for adding a new learner. Triggers on new backend implementations.
+> - [`rieszreg-cross-package-change`](.claude/skills/rieszreg-cross-package-change/SKILL.md) — prose-and-examples sweep after a public-API rename.
 
-- [`rieszreg/`](rieszreg/) — meta-package: shared abstractions (`Estimand`, `Loss`, `RieszEstimator`, augmentation, diagnostics, `Backend` and `MomentBackend` Protocols, testing utilities, R6 base class).
-- [`rieszboost/`](rieszboost/) — gradient-boosting backend (Lee & Schuler 2025; uses `Backend.fit_augmented`).
-- [`krrr/`](krrr/) — kernel-ridge backend (Singh 2021; uses `Backend.fit_augmented`).
-- [`forestriesz/`](forestriesz/) — random-forest backend (Chernozhukov, Newey, Quintas-Martínez, Syrgkanis ICML 2022; uses `MomentBackend.fit_rows`).
-- [`riesznet/`](riesznet/) — neural-network backend (Chernozhukov, Newey, Quintas-Martínez, Syrgkanis 2021, Riesz-rep only; uses `MomentBackend.fit_rows` with PyTorch autograd).
+A uv-workspace monorepo for the Riesz-regression package family. Six members under `packages/`:
 
-Implementation packages depend on `rieszreg` and provide concrete backends. The design doc lives inside the meta-package itself ([`rieszreg/DESIGN.md`](rieszreg/DESIGN.md)) so every collaborator who clones rieszreg gets it.
-
-## GitHub home
-
-All packages in this family live under the [`rieszreg` GitHub org](https://github.com/rieszreg). When creating a new learner package (or any new repo in the family — examples, downstream wrappers, paper artifacts), create it directly in `rieszreg/`, not under a personal account:
-
-```sh
-gh repo create rieszreg/<new-pkg> --public --source=. --remote=origin --description "..."
-```
-
-The unified docs CI, the per-package `test.yml` files (which check out `rieszreg` as a sibling via `repository: rieszreg/rieszreg`), and the cross-references in `README.md` / `docs/*.qmd` all assume the org-level path.
-
-## Dependency graph
-
-```
-rieszreg (no deps on impl packages)
-   ↑
-   ├── rieszboost      (XGBoostBackend, SklearnBackend, RieszBooster)        [fit_augmented]
-   ├── krrr            (KernelRidgeBackend, kernels, solvers, KernelRieszRegressor)  [fit_augmented]
-   ├── forestriesz     (ForestRieszBackend, ForestRieszRegressor)            [fit_rows]
-   ├── riesznet        (TorchBackend, TorchPredictor, RieszNet)              [fit_rows]
-   └── <future-pkg>    (its backend(s) + thin convenience class)
-```
-
-## Where things live
-
-| Concern | Home |
+| Member | Role |
 |---|---|
-| `Estimand` base class + 5 built-in subclasses (ATE, ATT, TSM, AdditiveShift, LocalShift), `LinearForm`, `Tracer` | `rieszreg/python/rieszreg/estimands/` |
-| `Loss` base class + 4 built-in losses | `rieszreg/python/rieszreg/losses/` |
-| `AugmentedDataset` packaging | `rieszreg/python/rieszreg/augmentation.py` |
-| `Backend` and `MomentBackend` Protocols + predictor-loader registry | `rieszreg/python/rieszreg/backends/base.py` |
-| `Diagnostics` base class + `diagnose()` | `rieszreg/python/rieszreg/diagnostics.py` |
-| `RieszEstimator` (sklearn orchestrator) | `rieszreg/python/rieszreg/estimator.py` |
-| Canonical DGPs, sklearn-conformance, parity helpers | `rieszreg/python/rieszreg/testing/` |
-| Shared base R6 class | `rieszreg/r/rieszreg/R/rieszreg.R` |
-| User guide (single Quarto site) | `docs/` |
-| Reference papers | `reference/` |
-| Pre-commit hook template | `.githooks/pre-commit` (each package keeps a copy) |
-| CI workflow templates | `.github/workflows/` |
-| Concrete backends + convenience subclasses | each implementation package's `python/<pkg>/backends/` and `python/<pkg>/<estimator>.py` |
+| [`packages/rieszreg`](packages/rieszreg) | meta-package: shared `Estimand`, `Loss`, `RieszEstimator`, augmentation, diagnostics, `Backend` / `MomentBackend` Protocols, R6 base class |
+| [`packages/rieszboost`](packages/rieszboost) | gradient-boosting learner (Lee & Schuler 2025; `fit_augmented`) |
+| [`packages/krrr`](packages/krrr) | kernel-ridge learner (Singh 2021; `fit_augmented`) |
+| [`packages/forestriesz`](packages/forestriesz) | random-forest learner (Chernozhukov et al. ICML 2022; `fit_rows`) |
+| [`packages/riesznet`](packages/riesznet) | neural-network learner (Chernozhukov et al. 2021; `fit_rows`) |
+| [`packages/riesztree`](packages/riesztree) | single-tree learner (Schuler 2026; `fit_augmented`) |
 
-## Adding a new estimand or loss
+Each member has the structure `packages/<pkg>/python/<pkg>/` (Python source + tests) and `packages/<pkg>/r/<pkg>/` (R wrapper). The five non-meta members declare `dependencies = ["rieszreg"]` in their `pyproject.toml`; uv resolves that to the local workspace member, not PyPI.
 
-Goes in `rieszreg`, not the implementation packages.
+## Layout
 
-1. Add the factory / class in `rieszreg/python/rieszreg/estimands/base.py` (or `losses/<name>.py`).
-2. Wire into the relevant `__init__.py` and the `_FACTORY_REGISTRY` / `loss_from_spec` registry.
-3. Update the docs page (`docs/estimands.qmd` or `docs/losses.qmd`) and the README.
-4. Add a test under `rieszreg/python/tests/`.
-5. Implementation packages whose backend supports the new feature should add a smoke test confirming round-trip works.
-
-## Adding a new backend
-
-Pick the entry point that matches your learner's natural loss decomposition:
-
-- **Augmentation-style** (kernel ridge, gradient boosting): implement `Backend.fit_augmented` from `rieszreg/python/rieszreg/backends/base.py`. The orchestrator pre-computes the augmented `(a, b)` dataset for you. References: `KernelRidgeBackend` (krrr), `XGBoostBackend` (rieszboost).
-- **Moment-style** (random forests, neural nets): implement `MomentBackend.fit_rows` from the same file. You receive raw rows + the estimand and call `rieszreg.trace(estimand, row)` per row to compute moments. Reference: `ForestRieszBackend` (forestriesz).
-
-Register the predictor loader on import:
-
-```python
-from rieszreg.backends import register_predictor_loader
-register_predictor_loader("my-kind", MyPredictor.load)
 ```
-
-Provide a convenience class subclassing `rieszreg.RieszEstimator`. Subclass `rieszreg::RieszEstimatorR6` for the R wrapper. See `rieszreg/DESIGN.md` (Part B) for the full contract.
+RieszReg/
+├── pyproject.toml            workspace root
+├── uv.lock
+├── DESIGN.md                 architectural contract
+├── docs/                     unified Quarto site (covers all six)
+├── reference/                arXiv PDFs
+├── .github/workflows/        test.yml (matrix all six × 2 OS × 2 Py), docs.yml, release.yml
+└── packages/
+    └── <pkg>/
+        ├── pyproject.toml
+        ├── python/<pkg>/      Python source
+        ├── python/tests/
+        └── r/<pkg>/           R wrapper (DESCRIPTION + R/ + tests/testthat/)
+```
 
 ## Run tests
 
 ```sh
-.venv/bin/python -m pytest rieszreg/python/tests -q
-.venv/bin/python -m pytest rieszboost/python/tests -q
-.venv/bin/python -m pytest krrr/python/tests -q
-.venv/bin/python -m pytest forestriesz/python/tests -q
-.venv/bin/python -m pytest riesznet/python/tests -q
+uv sync --all-packages --all-extras
+uv run pytest packages/<pkg>/python/tests -q          # one package
+for p in rieszreg rieszboost krrr forestriesz riesznet riesztree; do
+  uv run pytest packages/$p/python/tests -q
+done                                                   # all packages
+```
 
-Rscript -e '
-  Sys.setenv(RETICULATE_PYTHON = file.path(getwd(), ".venv/bin/python"))
-  pkgload::load_all("rieszreg/r/rieszreg")
-  pkgload::load_all("rieszboost/r/rieszboost")
-  testthat::test_dir("rieszboost/r/rieszboost/tests/testthat")
-  pkgload::load_all("krrr/r/krrr")
-  testthat::test_dir("krrr/r/krrr/tests/testthat")
-  pkgload::load_all("forestriesz/r/forestriesz")
-  testthat::test_dir("forestriesz/r/forestriesz/tests/testthat")
-  pkgload::load_all("riesznet/r/riesznet")
-  testthat::test_dir("riesznet/r/riesznet/tests/testthat")
+R parity tests:
+
+```sh
+uv run Rscript -e '
+  pkgload::load_all("packages/rieszreg/r/rieszreg")
+  for (p in c("rieszboost","krrr","forestriesz","riesznet","riesztree")) {
+    pkgload::load_all(file.path("packages", p, "r", p))
+    testthat::test_dir(file.path("packages", p, "r", p, "tests", "testthat"))
+  }
 '
 ```
 
-## Doc-tone rules (enforced by .githooks/pre-commit)
+See [`rieszreg-dev-environment`](.claude/skills/rieszreg-dev-environment/SKILL.md) for worktree usage and Quarto rendering.
 
-User-facing docs describe what's currently in the package, in plain instructive prose matching the [ngboost user guide](https://stanfordmlgroup.github.io/ngboost/intro.html). Two failure modes the hook checks for:
+## Adding a new estimand, loss, or learner
 
-1. **No design-decision metacommentary.** Don't explain the API's negative space — what we removed, intentionally didn't build, or chose between. Just describe what the function does and how to use it.
-2. **No AI-flavored hedge or editorial framing.** Avoid phrases like "the workhorse", "the right choice for almost every", "almost never needs tuning", "the natural way/API", "rather than reinvent". Avoid em-dashes peppered through prose. Sentences should be short (8–15 words on average), active voice.
+- **Estimand or loss** → `packages/rieszreg/python/rieszreg/{estimands,losses}/`. Steps in [`DESIGN.md`](DESIGN.md) §A.3.
+- **Learner (new backend)** → new `packages/<pkg>/`, follow the contract in [`DESIGN.md`](DESIGN.md) Part B. The [`rieszreg-backend-contract`](.claude/skills/rieszreg-backend-contract/SKILL.md) skill is the triggered short form of that contract.
 
-## sklearn-first rule
+## Releases
 
-Before writing any procedural code with loops, splits, grids, or folds, ask *"is there an sklearn way?"*. If yes, use it. Bespoke is reserved for things sklearn genuinely doesn't cover (the `LinearForm` tracer, the custom xgboost objective, the Bregman `Loss`).
-
-## Status
-
-- rieszreg: 71 Python tests passing (unit tests for tracer, losses, estimands, augmentation, diagnostics, orchestrator with stub backends — both `Backend` and `MomentBackend` dispatch paths covered, testing utilities).
-- rieszboost: 112 Python tests + 11 R parity tests passing.
-- krrr: 36 Python tests + 1 R parity test passing.
-- forestriesz: 55 Python tests + 1 R parity test passing.
-- riesznet: 41 Python tests + 1 R parity test passing.
-- Unified Quarto docs site renders all 17 pages (neural backend page added).
-- Pre-commit hook + CI workflow templates wired but not yet activated by `git config core.hooksPath` in any clone.
+Per-package PyPI releases via tag prefix: `<pkg>-vX.Y.Z` (e.g. `rieszboost-v0.1.0`). The `.github/workflows/release.yml` workflow uses Trusted Publisher OIDC — set up the trusted-publisher relationship on PyPI per package before the first release.


### PR DESCRIPTION
Follow-up to #41 (the monorepo migration). Updates the meta documentation and skills to reflect the new layout and adds research-code coding guidance.

## What changes

**`CLAUDE.md`** — rewritten for the monorepo (~70 lines, was 135):
- Top of file states the research-code mindset (breaking changes fine, no deprecation shims, tests for statistical correctness rather than warnings firing).
- Removes Status section, inline sklearn-first, inline doc-tone — those move into skills.
- Replaces the multi-repo dependency graph + "Where things live" table with the single `packages/<pkg>/` layout.
- Replaces multi-checkout test commands with `uv run pytest packages/<pkg>/python/tests`.

**`.claude/skills/rieszreg-dev-environment/SKILL.md`** — full rewrite. Drops obsolete worktree-namespace warnings and sibling-not-in-worktree rules (fixed by the migration). Adds: `uv sync` workflow, the leftover-`<pkg>/` shadowing diagnosis, Quarto operational tips (_freeze cache, killing hung renders), R parity test pattern.

**`.claude/skills/rieszreg-notation/SKILL.md`** — add §14 (Doc-tone, banned phrases) absorbing the section that used to live in `CLAUDE.md`, and §15 (Living-doc rule).

**`.claude/skills/rieszreg-coding/SKILL.md`** — NEW. Single skill covering:
1. Research code, not production. Breaking changes fine. No deprecation shims. Don't add defensive input validation for scenarios that can't happen.
2. OOP-first. Extend existing classes when conceptually right. Prefer fewer lines over more. Don't add new files for what could be a method on an existing class.
3. Tier-1/2/3 placement (the `would-be-ignored` lint test).
4. sklearn-first.
5. Test philosophy — test that the library does what it's meant to do statistically; don't test that warnings fire or that input rejection works.

**`.claude/skills/rieszreg-backend-contract/SKILL.md`** — NEW. Triggered short form of `DESIGN.md` Part B for adding a new learner.

**`.claude/skills/rieszreg-cross-package-change/SKILL.md`** — NEW. Reduced-scope sweep checklist after a public-API rename in `packages/rieszreg/` (in monorepo, the rename itself is one commit; this skill is for the prose-and-examples sweep).

## Verified

This is a docs-only PR (no code, no test changes). CI should run all six pytest matrices unchanged, all five rtests, and docs render unchanged. No expected failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)