### PR TITLE
docs: add extending.qmd for end-user learner wrapping

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -47,6 +47,7 @@ website:
           - estimation/custom.qmd
           - estimation/external.qmd
       - troubleshooting.qmd
+      - extending.qmd
       - developing.qmd
       - related.qmd
       - references.qmd

--- a/docs/extending.qmd
+++ b/docs/extending.qmd
@@ -1,0 +1,192 @@
+---
+title: "Extending: wrap your own learner"
+---
+
+The `RieszEstimator` orchestrator is learner-agnostic. To run it with an algorithm we don't ship, wrap that algorithm as a small class that satisfies one Protocol and register a predictor loader. This page walks through the minimum viable wrapper, a worked example, and how to plug it into `cross_val_predict`, `GridSearchCV`, and `Pipeline`.
+
+This is the end-user route: keep the wrapper in your own module, depend on `rieszreg`, ship nothing back. Contributing a learner package to the family adds a few requirements (R parity, the full conformance suite, in-tree tier placement) covered in [`DESIGN.md` Part B](https://github.com/rieszreg/rieszreg/blob/main/DESIGN.md).
+
+## Pick an entry point
+
+Two Protocols live in `rieszreg.backends.base`. Each backend implements one.
+
+`Backend.fit_augmented(aug_train, aug_valid, loss, …)` is for learners whose loss decomposes naturally over augmented evaluation points. The orchestrator hands you an `AugmentedDataset` of pseudo-rows with `is_original` and `potential_deriv_coef` columns. The empirical Bregman-Riesz loss at $\alpha$ is the sum over augmented rows $r$ of $D_r\,\tilde h(\alpha(Z_r)) + C_r\,h'(\alpha(Z_r))$, where $D_r$ is `is_original` and $C_r$ is `potential_deriv_coef`. Reference learners using this entry point: kernel ridge (`KernelRidgeBackend`) and gradient boosting (`XGBoostBackend`, `SklearnBackend`).
+
+`MomentBackend.fit_rows(rows_train, rows_valid, estimand, loss, …)` is for learners whose loss decomposes per original row. You receive raw rows plus the estimand, and you call `rieszreg.trace(estimand, row, y)` per row to read the $(c_j, a_j)$ pairs. Each row contributes a single loss term, so there is no $k+1$-fold augmentation blow-up. Reference learners using this entry point: random forests (`ForestRieszBackend`) and neural nets (`TorchBackend`).
+
+Pick by your learner's natural loss decomposition. Closed-form linear solves and gradient boosting fit `fit_augmented`, because the augmented sum has the same shape as a per-row weighted regression. Random forests and neural nets fit `fit_rows`, because each original row is a single training example to the underlying learner. When both fit, pick `fit_augmented`: the orchestrator dispatches to the moment path only when `fit_rows` is the only method present.
+
+## Minimum viable wrapper
+
+Three pieces: a backend class implementing one Protocol method, a predictor class with `predict_eta` and `predict_alpha`, and a one-line registration of the predictor's loader. All three live in your own module.
+
+### Augmentation-style
+
+```python
+import numpy as np
+from rieszreg.backends import (
+    FitResult, register_predictor_loader,
+)
+
+class MyLearnerPredictor:
+    kind = "my-learner"          # registry key, must be unique
+
+    def __init__(self, params, base_score, loss):
+        self.params = params      # whatever your learner returns
+        self.base_score = base_score
+        self.loss = loss
+
+    def predict_eta(self, features):
+        return self.base_score + my_learner_predict(self.params, features)
+
+    def predict_alpha(self, features):
+        return self.loss.link_to_alpha(self.predict_eta(features))
+
+    def save(self, dir_path):
+        np.save(dir_path / "params.npy", self.params)
+
+    @classmethod
+    def load(cls, dir_path, *, base_score, loss, best_iteration):
+        params = np.load(dir_path / "params.npy")
+        return cls(params=params, base_score=base_score, loss=loss)
+
+
+class MyLearnerBackend:
+    """Augmentation-style wrapper around `my_learner_fit`."""
+
+    def __init__(self, regularization=1.0, validation_fraction=0.0):
+        self.regularization = regularization
+        self.validation_fraction = validation_fraction
+
+    def fit_augmented(self, aug_train, aug_valid, loss,
+                      *, base_score, random_state, hyperparams):
+        # Each augmented row contributes D · h_tilde(α) + C · h'(α) to the loss.
+        # Translate (features, D, C) into whatever your learner consumes.
+        params = my_learner_fit(
+            features=aug_train.features,
+            is_original=aug_train.is_original,
+            potential_deriv_coef=aug_train.potential_deriv_coef,
+            regularization=self.regularization,
+            random_state=random_state,
+        )
+        predictor = MyLearnerPredictor(params, base_score=base_score, loss=loss)
+        return FitResult(predictor=predictor)
+
+
+register_predictor_loader("my-learner", MyLearnerPredictor.load)
+```
+
+### Moment-style
+
+Replace `fit_augmented` with `fit_rows`. The predictor stays the same.
+
+```python
+from rieszreg import trace
+
+class MyMomentBackend:
+    def __init__(self, learning_rate=1e-3):
+        self.learning_rate = learning_rate
+
+    def fit_rows(self, rows_train, rows_valid, estimand, loss,
+                 *, base_score, random_state, hyperparams,
+                 ys_train=None, ys_valid=None):
+        # For each row i, trace(...) returns the pairs (c_j, a_j) where
+        # m(α)(Z_i, Y_i) = sum_j c_j · α(a_j). Each row's contribution
+        # to the empirical loss is α(Z_i)² − 2 · sum_j c_j · α(a_j) for
+        # squared loss; the general Bregman form lives on `loss`.
+        moments = []
+        for i, row in enumerate(rows_train):
+            y_i = ys_train[i] if ys_train is not None else None
+            moments.append(trace(estimand, row, y_i))
+
+        params = my_moment_fit(
+            rows_train, moments,
+            learning_rate=self.learning_rate,
+            random_state=random_state,
+        )
+        predictor = MyLearnerPredictor(params, base_score=base_score, loss=loss)
+        return FitResult(predictor=predictor)
+```
+
+`Backend`, `MomentBackend`, `Predictor`, and `FitResult` are all importable from `rieszreg.backends`. The Protocols are structural (`typing.Protocol`), so your wrapper does not need to inherit from anything as long as the method signatures match.
+
+## Worked example
+
+The canonical linear-Gaussian DGP from `rieszreg.testing.dgps` is a binary treatment $A \in \{0, 1\}$ with covariate $X \in \mathbb R$ and propensity $\pi(x) = \mathrm{logit}^{-1}(0.5\,x)$. The true representer for ATE is the inverse propensity weight $\alpha_0(A, X) = (2A - 1) \,/\, [A\pi(X) + (1-A)(1-\pi(X))]$.
+
+```python
+import numpy as np
+from rieszreg import RieszEstimator, ATE
+from rieszreg.testing.dgps import linear_gaussian_ate
+
+dgp = linear_gaussian_ate()
+df = dgp.sample(n=2000, rng=np.random.default_rng(0))
+Z = df[["a", "x"]]
+y = df["y"]
+
+est = RieszEstimator(
+    estimand=ATE(treatment="a", covariates=("x",)),
+    backend=MyLearnerBackend(regularization=0.1),
+).fit(Z, y)
+
+alpha_hat = est.predict(Z)
+alpha_true = dgp.true_alpha(df)
+print(f"Pearson(α̂, α₀) = {np.corrcoef(alpha_hat, alpha_true)[0, 1]:.3f}")
+```
+
+`RieszEstimator.fit` reads `feature_keys` off the estimand, builds the augmented dataset by tracing $m$ row by row, computes `base_score` from the loss and the empirical mean $\bar m = \mathbb E_n[m(\alpha = 1)(Z, Y)]$, and dispatches to `MyLearnerBackend.fit_augmented`. The fitted predictor gets stored on `est.predictor_`. `est.predict(Z)` calls `predictor.predict_alpha(features)` on the rows you pass in.
+
+`y` is the per-row outcome vector. Built-in estimands ignore it; pass it anyway so the call follows the sklearn convention. Custom $Y$-dependent estimands receive it inside `m(\alpha)(z, y)`.
+
+## Sklearn composition
+
+`RieszEstimator` already inherits from `sklearn.base.BaseEstimator`. Composition with `cross_val_predict`, `GridSearchCV`, `clone`, and `Pipeline` works as long as the wrapper plays by sklearn's two structural rules.
+
+**The constructor stores its arguments by name without modification.** `MyLearnerBackend.__init__` writes `self.regularization = regularization` and stops. No coercion, no validation, no derived attributes. `clone(MyLearnerBackend(regularization=0.1))` then returns a fresh equivalent object, which sklearn relies on between folds.
+
+**Fit-time state lives on the predictor, not on the backend.** The backend stays clone-clean across folds; fitted parameters live on the `Predictor` returned in `FitResult`, attached to `est.predictor_` after `fit`.
+
+With those two in place, the standard sklearn idioms compose:
+
+```python
+from sklearn.model_selection import cross_val_predict, GridSearchCV, KFold
+
+cv = KFold(n_splits=5, shuffle=True, random_state=0)
+
+# Cross-fit α̂ for downstream DML / TMLE.
+alpha_oof = cross_val_predict(est, Z, y, cv=cv)
+
+# Tune the regularization on held-out Riesz loss.
+grid = GridSearchCV(
+    estimator=est,
+    param_grid={"backend__regularization": [0.01, 0.1, 1.0, 10.0]},
+    cv=cv,
+).fit(Z, y)
+print(grid.best_params_)
+```
+
+`backend__regularization` is sklearn's nested-parameter syntax. It forwards to `est.backend.regularization` so any backend hyperparameter exposed as a constructor attribute is reachable.
+
+If your backend uses a held-out slice for fit-time logic such as early stopping or regularization-path selection, expose `validation_fraction` as a constructor attribute. The orchestrator reads it via `getattr` and splits the rows before augmentation. Backends that compute their own internal CV or that don't need a holdout leave the attribute off.
+
+## Save, load, conformance
+
+`RieszEstimator.save(path)` writes `metadata.json` (loss spec, estimand factory_spec, base_score, your `predictor.kind`) and calls `predictor.save(dir_path)` for the binary payload. `RieszEstimator.load(path)` reads the metadata and looks up your registered predictor loader by `kind`. Built-in estimands round-trip automatically; custom estimands require `RieszEstimator.load(path, estimand=...)` so the user's $m$ is back in scope.
+
+Run `register_predictor_loader("my-learner", MyLearnerPredictor.load)` at the top level of your wrapper module so `import my_wrapper` registers the loader.
+
+`rieszreg.testing.conformance` ships small helpers (`assert_clone_roundtrip`, `assert_get_params_round_trip`) that verify the load-bearing sklearn properties on your wrapper:
+
+```python
+from rieszreg.testing.conformance import assert_clone_roundtrip
+
+def test_clone():
+    assert_clone_roundtrip(
+        lambda: RieszEstimator(
+            estimand=ATE(treatment="a", covariates=("x",)),
+            backend=MyLearnerBackend(regularization=0.1),
+        )
+    )
+```
+
+For a private wrapper, those two helpers plus a fit/predict/score smoke test on `linear_gaussian_ate` cover the regression surface. The full suite (`GridSearchCV`, `cross_val_predict`, save/load on every built-in estimand, the [estimator-consistency suite](https://github.com/rieszreg/rieszreg/blob/main/packages/rieszreg/python/rieszreg/testing/dgps.py) over the canonical DGPs) is the bar an in-tree contributed learner has to clear.


### PR DESCRIPTION
## Summary
- New [docs/extending.qmd](docs/extending.qmd) documents the end-user route to plug a custom learner into `RieszEstimator` without contributing the wrapper back upstream.
- Covers picking between `Backend.fit_augmented` (augmentation-style, e.g. kernel ridge / boosting) and `MomentBackend.fit_rows` (moment-style, e.g. forests / neural nets), the minimum viable wrapper (predictor + backend + loader registration), a worked example on the canonical linear-Gaussian ATE DGP, sklearn composition (`cross_val_predict`, `GridSearchCV`), and a brief mention of save/load + the `testing.conformance` helpers.
- Wired into the sidebar between `troubleshooting.qmd` and `developing.qmd` so end users see the wrapping page before the contributor-facing tier-1/2/3 page.

[`DESIGN.md` Part B](DESIGN.md) stays the in-tree contributor contract (R parity, full conformance suite, tier placement). The new page is the public-API view of the same Protocol surface.

## Test plan
- [x] `quarto render docs/extending.qmd` renders cleanly
- [x] Sidebar links resolve (verified in rendered HTML)
- [ ] Reviewer eyes on notation conventions ($\\mu, \\alpha, \\psi, m$; $Z = (A, X)$; "estimand", "learner") and doc-tone rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)